### PR TITLE
Simplify Mac dependency installation process

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -78,8 +78,8 @@ import subprocess, sys
 subprocess.run([sys.executable, "-m", "pip", "install", "numpy"])
 subprocess.run([sys.executable, "-m", "pip", "install", "scipy"])
 subprocess.run([sys.executable, "-m", "pip", "install", "pandas"])
+subprocess.run([sys.executable, "-m", "pip", "install", "numba"])  # Install before libpysal/esda
 subprocess.run([sys.executable, "-m", "pip", "install", "libpysal", "esda", "--no-build-isolation"])
-subprocess.run([sys.executable, "-m", "pip", "install", "numba"])
 subprocess.run([sys.executable, "-m", "pip", "install", "matplotlib"])  # Optional
 ```
 
@@ -90,7 +90,7 @@ subprocess.run([sys.executable, "-m", "pip", "install", "matplotlib"])  # Option
 **Option 3 - Single Terminal Command:**
 
 ```bash
-/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install numpy scipy pandas libpysal esda numba matplotlib --no-build-isolation
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install numpy scipy pandas numba libpysal esda matplotlib --no-build-isolation
 ```
 
 **Option 4 - Shell Script:**

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -60,37 +60,44 @@ python3 -m pip install libpysal numba matplotlib
 
 ### macOS
 
-**Option 1 - Automated Script (Recommended):**
+**RECOMMENDED: Use QGIS Python Console** (most reliable - impossible to use wrong Python)
 
-Run `install_mac_dependencies.py` from QGIS Python Console (see README for details) or:
+**Option 1 - QGIS Console Script (Easiest):**
 
-```bash
-/Applications/QGIS.app/Contents/MacOS/bin/python3 install_mac_dependencies.py
+1. Open QGIS → Plugins → Python Console
+2. Click "Show Editor" → "Open Script"
+3. Select `install_dependencies_console.py`
+4. Click "Run Script"
+
+**Option 2 - QGIS Console Manual Commands:**
+
+Run in QGIS Python Console (one at a time):
+
+```python
+import pip
+pip.main(['install', 'numpy'])
+pip.main(['install', 'scipy'])
+pip.main(['install', 'pandas'])
+pip.main(['install', 'libpysal', 'esda', '--no-build-isolation'])
+pip.main(['install', 'numba'])
+pip.main(['install', 'matplotlib'])  # Optional
 ```
 
-**Option 2 - Shell Script:**
+**Alternative: Terminal Methods** (advanced users only)
 
-```bash
-bash install_mac_dependencies.sh
-```
-
-**Option 3 - Single Command (All dependencies):**
+**Option 3 - Single Terminal Command:**
 
 ```bash
 /Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install numpy scipy pandas libpysal esda numba matplotlib --no-build-isolation
 ```
 
-**Option 4 - Manual (Individual packages):**
+**Option 4 - Shell Script:**
 
 ```bash
-# Using QGIS Python
-/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install numpy
-/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install scipy
-/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install pandas
-/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install libpysal esda --no-build-isolation
-/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install numba
-/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install matplotlib  # Optional
+bash install_mac_dependencies.sh
 ```
+
+**Note:** Terminal methods require using the exact QGIS Python path. Using just `python3` will install to the wrong Python!
 
 ### Linux
 

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -60,9 +60,36 @@ python3 -m pip install libpysal numba matplotlib
 
 ### macOS
 
+**Option 1 - Automated Script (Recommended):**
+
+Run `install_mac_dependencies.py` from QGIS Python Console (see README for details) or:
+
+```bash
+/Applications/QGIS.app/Contents/MacOS/bin/python3 install_mac_dependencies.py
+```
+
+**Option 2 - Shell Script:**
+
+```bash
+bash install_mac_dependencies.sh
+```
+
+**Option 3 - Single Command (All dependencies):**
+
+```bash
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install numpy scipy pandas libpysal esda numba matplotlib --no-build-isolation
+```
+
+**Option 4 - Manual (Individual packages):**
+
 ```bash
 # Using QGIS Python
-/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install libpysal numba matplotlib
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install numpy
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install scipy
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install pandas
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install libpysal esda --no-build-isolation
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install numba
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install matplotlib  # Optional
 ```
 
 ### Linux

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -74,14 +74,16 @@ python3 -m pip install libpysal numba matplotlib
 Run in QGIS Python Console (one at a time):
 
 ```python
-import pip
-pip.main(['install', 'numpy'])
-pip.main(['install', 'scipy'])
-pip.main(['install', 'pandas'])
-pip.main(['install', 'libpysal', 'esda', '--no-build-isolation'])
-pip.main(['install', 'numba'])
-pip.main(['install', 'matplotlib'])  # Optional
+import subprocess, sys
+subprocess.run([sys.executable, "-m", "pip", "install", "numpy"])
+subprocess.run([sys.executable, "-m", "pip", "install", "scipy"])
+subprocess.run([sys.executable, "-m", "pip", "install", "pandas"])
+subprocess.run([sys.executable, "-m", "pip", "install", "libpysal", "esda", "--no-build-isolation"])
+subprocess.run([sys.executable, "-m", "pip", "install", "numba"])
+subprocess.run([sys.executable, "-m", "pip", "install", "matplotlib"])  # Optional
 ```
+
+**Note:** Use `subprocess.run` with `sys.executable -m pip` (not `pip.main()`) for stability.
 
 **Alternative: Terminal Methods** (advanced users only)
 
@@ -95,6 +97,16 @@ pip.main(['install', 'matplotlib'])  # Optional
 
 ```bash
 bash install_mac_dependencies.sh
+```
+
+**Automation / CI / QGIS-LTR:**
+
+```bash
+# Non-interactive Python script
+/Applications/QGIS.app/Contents/MacOS/bin/python3 install_mac_dependencies.py --yes --log /tmp/install.log
+
+# Shell script with custom QGIS path
+QGIS_PYTHON="/Applications/QGIS-LTR.app/Contents/MacOS/bin/python3" bash install_mac_dependencies.sh
 ```
 
 **Note:** Terminal methods require using the exact QGIS Python path. Using just `python3` will install to the wrong Python!

--- a/INSTALL_MAC.md
+++ b/INSTALL_MAC.md
@@ -56,8 +56,8 @@ subprocess.run([sys.executable, "-m", "pip", "install", "--upgrade", "pip"])
 subprocess.run([sys.executable, "-m", "pip", "install", "numpy"])
 subprocess.run([sys.executable, "-m", "pip", "install", "scipy"])
 subprocess.run([sys.executable, "-m", "pip", "install", "pandas"])
+subprocess.run([sys.executable, "-m", "pip", "install", "numba"])  # Install numba before libpysal/esda
 subprocess.run([sys.executable, "-m", "pip", "install", "libpysal", "esda", "--no-build-isolation"])
-subprocess.run([sys.executable, "-m", "pip", "install", "numba"])
 subprocess.run([sys.executable, "-m", "pip", "install", "matplotlib"])  # Optional
 ```
 
@@ -77,7 +77,7 @@ subprocess.run([sys.executable, "-m", "pip", "install", "matplotlib"])  # Option
 **Terminal One-Liner:**
 
 ```bash
-/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install numpy scipy pandas libpysal esda numba matplotlib --no-build-isolation
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install numpy scipy pandas numba libpysal esda matplotlib --no-build-isolation
 ```
 
 **Shell Script:**

--- a/INSTALL_MAC.md
+++ b/INSTALL_MAC.md
@@ -51,15 +51,17 @@ This is the most reliable method because QGIS Python Console automatically uses 
 3. Copy and paste these commands **one at a time** (press Enter after each):
 
 ```python
-import pip
-pip.main(['install', 'pip', '--upgrade'])
-pip.main(['install', 'numpy'])
-pip.main(['install', 'scipy'])
-pip.main(['install', 'pandas'])
-pip.main(['install', 'libpysal', 'esda', '--no-build-isolation'])
-pip.main(['install', 'numba'])
-pip.main(['install', 'matplotlib'])  # Optional - for plotting
+import subprocess, sys
+subprocess.run([sys.executable, "-m", "pip", "install", "--upgrade", "pip"])
+subprocess.run([sys.executable, "-m", "pip", "install", "numpy"])
+subprocess.run([sys.executable, "-m", "pip", "install", "scipy"])
+subprocess.run([sys.executable, "-m", "pip", "install", "pandas"])
+subprocess.run([sys.executable, "-m", "pip", "install", "libpysal", "esda", "--no-build-isolation"])
+subprocess.run([sys.executable, "-m", "pip", "install", "numba"])
+subprocess.run([sys.executable, "-m", "pip", "install", "matplotlib"])  # Optional
 ```
+
+**Note:** We use `subprocess.run` with `sys.executable -m pip` (not `pip.main()`) because it's more stable across pip versions.
 
 4. Restart QGIS
 
@@ -83,6 +85,16 @@ pip.main(['install', 'matplotlib'])  # Optional - for plotting
 ```bash
 cd /path/to/GeoPublicHealth
 bash install_mac_dependencies.sh
+```
+
+**For automation / CI / QGIS-LTR:**
+
+```bash
+# Non-interactive mode with logging
+/Applications/QGIS.app/Contents/MacOS/bin/python3 install_mac_dependencies.py --yes --log /tmp/install.log
+
+# Override QGIS path for QGIS-LTR
+QGIS_PYTHON="/Applications/QGIS-LTR.app/Contents/MacOS/bin/python3" bash install_mac_dependencies.sh
 ```
 
 </details>

--- a/INSTALL_MAC.md
+++ b/INSTALL_MAC.md
@@ -2,6 +2,25 @@
 
 This is a simplified installation guide specifically for macOS users.
 
+## 🔑 Important: Understanding Python Environments
+
+**QGIS has its own Python** - it's completely separate from any other Python on your Mac.
+
+If you have multiple Python installations (Homebrew, Anaconda, system Python), **don't worry** - they won't interfere. But you need to install the plugin dependencies specifically into **QGIS's Python**, not your other Python installations.
+
+**Where is QGIS's Python?**
+- Location: `/Applications/QGIS.app/Contents/MacOS/bin/python3`
+- This is different from `/usr/bin/python3` (macOS system Python)
+- This is different from `/opt/homebrew/bin/python3` (Homebrew Python)
+- This is different from conda/anaconda Python
+
+**Why does this matter?**
+If you accidentally install dependencies to the wrong Python, QGIS won't be able to find them and the plugin won't work.
+
+**The good news:** The installation methods below automatically use the correct Python, so you don't have to worry about it! Just follow the steps. 🎉
+
+---
+
 ## Step 1: Install QGIS
 
 1. Download: [QGIS for macOS](https://download.qgis.org/downloads/macos/qgis-macos-pr.dmg)
@@ -59,6 +78,10 @@ Then restart QGIS.
 Open the QGIS Python Console and run:
 
 ```python
+import sys
+print(f"Python: {sys.executable}")
+print("(Should contain 'QGIS.app')\n")
+
 import libpysal, esda, numba
 print(f"✓ All dependencies installed!")
 print(f"  libpysal {libpysal.__version__}")
@@ -66,7 +89,15 @@ print(f"  esda {esda.__version__}")
 print(f"  numba {numba.__version__}")
 ```
 
+**What to check:**
+- The Python path should contain `QGIS.app` (confirms you're using QGIS's Python)
+- You should see version numbers for all three packages
+
 If you see version numbers, you're ready to go! 🎉
+
+**If it doesn't work:**
+- See the Troubleshooting section below
+- For detailed technical information: [MAC_INSTALL_TECHNICAL.md](MAC_INSTALL_TECHNICAL.md)
 
 ## Troubleshooting
 
@@ -93,6 +124,19 @@ Install XQuartz: https://www.xquartz.org/
 
 ## Need More Help?
 
+- **Technical details and advanced troubleshooting**: [MAC_INSTALL_TECHNICAL.md](MAC_INSTALL_TECHNICAL.md)
 - See full documentation: [README.md](README.md)
 - Dependency details: [DEPENDENCIES.md](DEPENDENCIES.md)
 - Report issues: [GitHub Issues](https://github.com/ePublicHealth/GeoPublicHealth/issues)
+
+---
+
+## For Advanced Users
+
+If you want to understand:
+- Why QGIS has its own Python
+- How Python environments work on Mac
+- Detailed installation methods and troubleshooting
+- Development workflows
+
+See the complete technical guide: **[MAC_INSTALL_TECHNICAL.md](MAC_INSTALL_TECHNICAL.md)**

--- a/INSTALL_MAC.md
+++ b/INSTALL_MAC.md
@@ -1,0 +1,98 @@
+# Quick Mac Installation Guide
+
+This is a simplified installation guide specifically for macOS users.
+
+## Step 1: Install QGIS
+
+1. Download: [QGIS for macOS](https://download.qgis.org/downloads/macos/qgis-macos-pr.dmg)
+2. Open the `.dmg` file and drag QGIS to Applications
+3. **First launch:** Right-click QGIS → Open (to bypass security warning)
+
+## Step 2: Install Dependencies
+
+Choose the method that works best for you:
+
+### 🌟 Easiest: Automated Script (Recommended)
+
+1. Download this repository (or just `install_mac_dependencies.py`)
+2. Open QGIS
+3. Go to **Plugins → Python Console**
+4. Click **"Show Editor"** button (toolbar icon)
+5. Click **"Open Script"** and select `install_mac_dependencies.py`
+6. Click **"Run Script"**
+7. Wait for completion
+8. Restart QGIS
+
+### ⚡ Fastest: Terminal One-Liner
+
+Open Terminal and paste:
+
+```bash
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install numpy scipy pandas libpysal esda numba matplotlib --no-build-isolation
+```
+
+Then restart QGIS.
+
+### 🔧 Alternative: Shell Script
+
+1. Download this repository
+2. Open Terminal
+3. Navigate to the folder: `cd /path/to/GeoPublicHealth`
+4. Run: `bash install_mac_dependencies.sh`
+5. Restart QGIS
+
+## Step 3: Install the Plugin
+
+1. Open QGIS
+2. Go to **Plugins → Manage and Install Plugins**
+3. Go to **Settings** tab
+4. Check **"Show also experimental plugins"**
+5. Click **Add** button:
+   - Name: `epublichealth`
+   - URL: `https://raw.githubusercontent.com/ePublicHealth/GeoPublicHealth/main/docs/plugins.xml`
+6. Go to **All** tab
+7. Search for `geopublichealth`
+8. Click **Install Plugin**
+
+## Verify Everything Works
+
+Open the QGIS Python Console and run:
+
+```python
+import libpysal, esda, numba
+print(f"✓ All dependencies installed!")
+print(f"  libpysal {libpysal.__version__}")
+print(f"  esda {esda.__version__}")
+print(f"  numba {numba.__version__}")
+```
+
+If you see version numbers, you're ready to go! 🎉
+
+## Troubleshooting
+
+### "ModuleNotFoundError: No module named 'libpysal'"
+
+The dependencies didn't install. Try the Terminal one-liner method above.
+
+### "Permission denied" errors
+
+Add `--user` flag:
+```bash
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install --user libpysal esda numba
+```
+
+### Plugin doesn't appear
+
+1. Check experimental plugins are enabled (see Step 3)
+2. Clear cache: `rm -rf ~/Library/Application\ Support/QGIS/QGIS3/profiles/default/cache`
+3. Restart QGIS
+
+### Library loading errors
+
+Install XQuartz: https://www.xquartz.org/
+
+## Need More Help?
+
+- See full documentation: [README.md](README.md)
+- Dependency details: [DEPENDENCIES.md](DEPENDENCIES.md)
+- Report issues: [GitHub Issues](https://github.com/ePublicHealth/GeoPublicHealth/issues)

--- a/INSTALL_MAC.md
+++ b/INSTALL_MAC.md
@@ -29,36 +29,63 @@ If you accidentally install dependencies to the wrong Python, QGIS won't be able
 
 ## Step 2: Install Dependencies
 
-Choose the method that works best for you:
+**✅ RECOMMENDED: Use QGIS Python Console**
 
-### 🌟 Easiest: Automated Script (Recommended)
+This is the most reliable method because QGIS Python Console automatically uses the correct Python environment - there's no way to accidentally use the wrong Python!
 
-1. Download this repository (or just `install_mac_dependencies.py`)
+### Method 1: Automated Script (Easiest - Just Click Run!)
+
+1. Download `install_dependencies_console.py` from this repository
 2. Open QGIS
 3. Go to **Plugins → Python Console**
 4. Click **"Show Editor"** button (toolbar icon)
-5. Click **"Open Script"** and select `install_mac_dependencies.py`
+5. Click **"Open Script"** and select `install_dependencies_console.py`
 6. Click **"Run Script"**
-7. Wait for completion
-8. Restart QGIS
+7. Watch the progress in the console
+8. Restart QGIS when complete
 
-### ⚡ Fastest: Terminal One-Liner
+### Method 2: Manual Console Commands (More Control)
 
-Open Terminal and paste:
+1. Open QGIS
+2. Go to **Plugins → Python Console**
+3. Copy and paste these commands **one at a time** (press Enter after each):
+
+```python
+import pip
+pip.main(['install', 'pip', '--upgrade'])
+pip.main(['install', 'numpy'])
+pip.main(['install', 'scipy'])
+pip.main(['install', 'pandas'])
+pip.main(['install', 'libpysal', 'esda', '--no-build-isolation'])
+pip.main(['install', 'numba'])
+pip.main(['install', 'matplotlib'])  # Optional - for plotting
+```
+
+4. Restart QGIS
+
+---
+
+### Alternative Methods (For Advanced Users)
+
+<details>
+<summary>Click to expand Terminal-based methods</summary>
+
+**⚠️ Warning:** These require using the exact QGIS Python path. The console methods above are more reliable.
+
+**Terminal One-Liner:**
 
 ```bash
 /Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install numpy scipy pandas libpysal esda numba matplotlib --no-build-isolation
 ```
 
-Then restart QGIS.
+**Shell Script:**
 
-### 🔧 Alternative: Shell Script
+```bash
+cd /path/to/GeoPublicHealth
+bash install_mac_dependencies.sh
+```
 
-1. Download this repository
-2. Open Terminal
-3. Navigate to the folder: `cd /path/to/GeoPublicHealth`
-4. Run: `bash install_mac_dependencies.sh`
-5. Restart QGIS
+</details>
 
 ## Step 3: Install the Plugin
 

--- a/MAC_INSTALL_TECHNICAL.md
+++ b/MAC_INSTALL_TECHNICAL.md
@@ -2,6 +2,8 @@
 
 This document provides detailed technical information about installing GeoPublicHealth dependencies on macOS, including Python environment management, troubleshooting, and advanced scenarios.
 
+> **TL;DR - Best Practice:** Use QGIS Python Console to run installation commands. This eliminates all Python environment confusion and is the most reliable method. See [Method 1: QGIS Python Console](#method-1-qgis-python-console-recommended---most-reliable) below.
+
 ## Table of Contents
 
 - [Understanding Python Environments](#understanding-python-environments)
@@ -103,23 +105,41 @@ Note: The exact paths may vary slightly between QGIS versions.
 
 ## Installation Methods Explained
 
-### Method 1: QGIS Python Console (Recommended)
+### Method 1: QGIS Python Console (RECOMMENDED - Most Reliable)
+
+**This is the recommended method for all users.**
 
 **Advantages:**
-- ✓ Always uses correct Python
+- ✓ **Impossible to use wrong Python** - console is already running in QGIS's Python
 - ✓ No Terminal knowledge required
-- ✓ Can't accidentally use wrong Python
+- ✓ No need to know or type QGIS Python path
 - ✓ Works even with restrictive permissions
+- ✓ Simplest and most foolproof method
+- ✓ Consistent across all macOS versions
 
 **How it works:**
-When you run code in QGIS Python Console, it uses QGIS's bundled Python interpreter automatically. The `pip.main()` function calls pip within the same Python environment.
+When you run code in QGIS Python Console, it uses QGIS's bundled Python interpreter automatically. The `pip.main()` function calls pip within the same Python environment that's currently running.
 
-**Commands:**
+**Two approaches:**
+
+**A. Automated Script** (`install_dependencies_console.py`):
+- Opens a script file in QGIS editor
+- Click "Run Script"
+- Handles all installations automatically
+- Shows progress and verifies success
+
+**B. Manual Commands:**
 ```python
 import pip
 pip.main(['install', 'libpysal', 'esda', '--no-build-isolation'])
 pip.main(['install', 'numba'])
 ```
+
+**Why this is better than Terminal:**
+- No risk of typos in Python path
+- No confusion about which `python3` command to use
+- Works regardless of PATH environment variable
+- No need to understand shell syntax
 
 **Why `--no-build-isolation`?**
 Some packages (like libpysal and esda) have build-time dependencies that need to be visible. The `--no-build-isolation` flag allows them to use already-installed packages during build, preventing errors.
@@ -404,13 +424,18 @@ brew install geos proj
 
 **Quick Reference:**
 
-| Method | Complexity | Reliability | Recommended For |
-|--------|------------|-------------|-----------------|
-| QGIS Python Console | Easy | Highest | Everyone, especially beginners |
-| Automated Script | Easy | High | Users who want automation |
-| Shell Script | Medium | High | Terminal users, automation |
-| One-liner | Medium | Medium | Advanced users, quick reinstall |
-| Manual | Hard | Medium | Troubleshooting, specific control |
+| Method | Complexity | Reliability | Environment Safety | Recommended For |
+|--------|------------|-------------|-------------------|-----------------|
+| **QGIS Console (pip.main)** | **Easy** | **Highest** | **100% Safe** | **Everyone - PRIMARY METHOD** |
+| QGIS Console Script | Easy | Highest | 100% Safe | Everyone who prefers automation |
+| Terminal One-liner | Medium | Medium | Requires exact path | Advanced users comfortable with Terminal |
+| Shell Script | Medium | Medium | Requires exact path | Terminal users, scripted deployments |
+| Terminal + subprocess script | Medium | Medium | Has environment check | Advanced troubleshooting |
+
+**Recommendation Priority:**
+1. 🥇 **QGIS Python Console** (manual commands or script) - Use this unless you have a specific reason not to
+2. 🥈 Terminal methods - Only for advanced users or automation scenarios
+3. 🥉 Other methods - For specific edge cases or troubleshooting
 
 ---
 

--- a/MAC_INSTALL_TECHNICAL.md
+++ b/MAC_INSTALL_TECHNICAL.md
@@ -222,7 +222,7 @@ LOG_DIR=/tmp bash install_mac_dependencies.sh
 
 **Command:**
 ```bash
-/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install numpy scipy pandas libpysal esda numba matplotlib --no-build-isolation
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install numpy scipy pandas numba libpysal esda matplotlib --no-build-isolation
 ```
 
 **Advantages:**
@@ -459,24 +459,60 @@ If you're developing plugins and want to test with development versions of depen
 
 3. Changes to the source code are immediately reflected in QGIS (after restart).
 
-### Scenario 3: Automating for Multiple Machines
+### Scenario 3: Reproducible Installations and Version Pinning
 
-Create a requirements.txt file:
+**Question:** How do I ensure consistent dependency versions across installations?
 
-```txt
-numpy>=1.20
-scipy>=1.7
-pandas>=1.3
-libpysal>=4.3.0
-esda>=2.4.0
-numba>=0.54
-matplotlib>=3.4
-```
+**Answer:** Use the provided `requirements-mac.txt` file with pinned versions.
 
-Install on each machine:
+**Why version pinning matters:**
+- The automated scripts install **latest versions** of packages
+- Latest versions may introduce breaking changes or incompatibilities
+- For production deployments or reproducible research, pinned versions are recommended
+- Pinned versions are tested and known to work together
+
+**Using pinned versions:**
+
+Option 1 - Terminal:
 ```bash
-/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install -r requirements.txt --no-build-isolation
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install -r requirements-mac.txt --no-build-isolation
 ```
+
+Option 2 - QGIS Python Console:
+```python
+import subprocess, sys
+subprocess.run([sys.executable, "-m", "pip", "install", "-r", "requirements-mac.txt", "--no-build-isolation"])
+```
+
+**Provided file:** `requirements-mac.txt` contains tested, compatible versions.
+
+**When to use:**
+- ✅ Production deployments
+- ✅ Reproducible research
+- ✅ CI/CD pipelines
+- ✅ When you need stable, tested versions
+
+**When NOT to use:**
+- ❌ Quick testing (use automated scripts instead)
+- ❌ Development (may want latest features)
+- ❌ When you specifically need newer versions
+
+**Security note:**
+For maximum security and reproducibility, you can add hashes to requirements:
+```bash
+# Generate hashes
+pip hash <package-name>==<version>
+
+# Install with hash verification
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install -r requirements-mac.txt --no-build-isolation --require-hashes
+```
+
+**Custom requirements file:**
+You can create your own based on `requirements-mac.txt`:
+1. Copy the file: `cp requirements-mac.txt my-requirements.txt`
+2. Modify versions as needed
+3. Test thoroughly before deploying
+4. Document tested QGIS/macOS versions in comments
 
 ### Scenario 4: Completely Clean Reinstall
 
@@ -494,7 +530,7 @@ If you need to start fresh:
 
 3. Reinstall:
    ```bash
-   /Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install --no-cache-dir numpy scipy pandas libpysal esda numba matplotlib --no-build-isolation
+   /Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install --no-cache-dir numpy scipy pandas numba libpysal esda matplotlib --no-build-isolation
    ```
 
 ### Scenario 5: Using Homebrew to Install System Dependencies

--- a/MAC_INSTALL_TECHNICAL.md
+++ b/MAC_INSTALL_TECHNICAL.md
@@ -1,0 +1,422 @@
+# macOS Installation - Technical Guide
+
+This document provides detailed technical information about installing GeoPublicHealth dependencies on macOS, including Python environment management, troubleshooting, and advanced scenarios.
+
+## Table of Contents
+
+- [Understanding Python Environments](#understanding-python-environments)
+- [QGIS Python Environment Details](#qgis-python-environment-details)
+- [Installation Methods Explained](#installation-methods-explained)
+- [Verifying Installation](#verifying-installation)
+- [Troubleshooting](#troubleshooting)
+- [Advanced Scenarios](#advanced-scenarios)
+
+---
+
+## Understanding Python Environments
+
+### The Problem: Multiple Python Installations
+
+macOS systems often have multiple Python installations:
+
+1. **System Python** (`/usr/bin/python3`)
+   - Built into macOS
+   - Should not be modified (protected by System Integrity Protection)
+   - Used by macOS system tools
+
+2. **Homebrew Python** (`/opt/homebrew/bin/python3` on Apple Silicon, `/usr/local/bin/python3` on Intel)
+   - Installed via `brew install python`
+   - User-managed, can install packages freely
+   - Common for developers
+
+3. **Anaconda/Miniconda Python**
+   - Typically in `~/anaconda3` or `~/miniconda3`
+   - Environment-based package management
+   - Popular for data science
+
+4. **QGIS Python** (`/Applications/QGIS.app/Contents/MacOS/bin/python3`)
+   - **Bundled with QGIS**
+   - **Isolated from all other Python installations**
+   - **This is where GeoPublicHealth dependencies MUST be installed**
+
+### Why QGIS Has Its Own Python
+
+QGIS bundles its own Python interpreter for several reasons:
+
+- **Version Control**: Ensures compatible Python version for QGIS features
+- **Dependency Isolation**: Avoids conflicts with system or user Python packages
+- **Portability**: QGIS works regardless of what Python is installed on the system
+- **Bundled Libraries**: Includes pre-compiled versions of GDAL, PyQt5, and other dependencies
+
+### The Critical Point
+
+**Installing packages to the wrong Python means QGIS won't find them.**
+
+When you run `pip install libpysal`, it installs to whichever Python's pip you're using:
+- `pip install libpysal` → installs to whatever `python3` is in your PATH (usually NOT QGIS)
+- `/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install libpysal` → installs to QGIS Python ✓
+
+---
+
+## QGIS Python Environment Details
+
+### Location
+
+```
+/Applications/QGIS.app/Contents/MacOS/bin/python3
+```
+
+### Version
+
+QGIS typically bundles Python 3.9 - 3.12 depending on the QGIS version:
+- QGIS 3.44: Python 3.12.x
+- QGIS 3.42: Python 3.11.x
+
+Check your version:
+```bash
+/Applications/QGIS.app/Contents/MacOS/bin/python3 --version
+```
+
+### Pre-installed Packages
+
+QGIS includes several packages by default:
+- `PyQt5` - GUI framework
+- `qgis` - PyQGIS libraries
+- `numpy` - Often included, but may need upgrade
+- `gdal` - Geospatial data abstraction library
+
+### Site-packages Location
+
+QGIS Python packages are installed to:
+```
+/Applications/QGIS.app/Contents/Resources/python/site-packages/
+```
+
+Or when using `--user` flag:
+```
+~/Library/Python/3.x/lib/python/site-packages/
+```
+
+Note: The exact paths may vary slightly between QGIS versions.
+
+---
+
+## Installation Methods Explained
+
+### Method 1: QGIS Python Console (Recommended)
+
+**Advantages:**
+- ✓ Always uses correct Python
+- ✓ No Terminal knowledge required
+- ✓ Can't accidentally use wrong Python
+- ✓ Works even with restrictive permissions
+
+**How it works:**
+When you run code in QGIS Python Console, it uses QGIS's bundled Python interpreter automatically. The `pip.main()` function calls pip within the same Python environment.
+
+**Commands:**
+```python
+import pip
+pip.main(['install', 'libpysal', 'esda', '--no-build-isolation'])
+pip.main(['install', 'numba'])
+```
+
+**Why `--no-build-isolation`?**
+Some packages (like libpysal and esda) have build-time dependencies that need to be visible. The `--no-build-isolation` flag allows them to use already-installed packages during build, preventing errors.
+
+### Method 2: Automated Python Script
+
+**File:** `install_mac_dependencies.py`
+
+**Advantages:**
+- ✓ Installs all dependencies automatically
+- ✓ Shows progress and verifies installation
+- ✓ Handles errors gracefully
+- ✓ Warns if using wrong Python
+
+**How it works:**
+Uses `subprocess` to call `pip` as a separate process, ensuring proper installation even in complex environments.
+
+### Method 3: Shell Script
+
+**File:** `install_mac_dependencies.sh`
+
+**Advantages:**
+- ✓ Terminal-based automation
+- ✓ Explicitly uses QGIS Python path
+- ✓ Comprehensive error checking
+- ✓ Good for scripted installations
+
+**How it works:**
+```bash
+QGIS_PYTHON="/Applications/QGIS.app/Contents/MacOS/bin/python3"
+$QGIS_PYTHON -m pip install libpysal esda --no-build-isolation
+```
+
+The script sets a variable to the QGIS Python path and uses it explicitly.
+
+### Method 4: Terminal One-Liner
+
+**Command:**
+```bash
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install numpy scipy pandas libpysal esda numba matplotlib --no-build-isolation
+```
+
+**Advantages:**
+- ✓ Fast and simple
+- ✓ Good for re-installation or updates
+- ✓ Explicitly targets QGIS Python
+
+**Disadvantages:**
+- ✗ Easy to typo the Python path
+- ✗ No error handling
+- ✗ Requires Terminal knowledge
+
+**Why `-m pip` instead of just `pip`?**
+Using `-m pip` ensures you're using the pip module for that specific Python, not a potentially different pip executable in your PATH.
+
+---
+
+## Verifying Installation
+
+### Check Which Python You're Using
+
+```bash
+which python3
+# Should show /opt/homebrew/bin/python3 or /usr/bin/python3 (NOT QGIS)
+
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -c "import sys; print(sys.executable)"
+# Should show the QGIS Python path
+```
+
+### Verify Dependencies in QGIS
+
+Open QGIS Python Console and run:
+
+```python
+import sys
+print("Python:", sys.executable)
+print()
+
+# Check required dependencies
+for module in ['libpysal', 'esda', 'numba', 'numpy']:
+    try:
+        mod = __import__(module)
+        version = getattr(mod, '__version__', 'unknown')
+        print(f"✓ {module} {version}")
+    except ImportError:
+        print(f"✗ {module} NOT FOUND")
+```
+
+### List All Installed Packages
+
+```python
+import subprocess
+import sys
+
+result = subprocess.run(
+    [sys.executable, '-m', 'pip', 'list'],
+    capture_output=True,
+    text=True
+)
+print(result.stdout)
+```
+
+---
+
+## Troubleshooting
+
+### Problem: "ModuleNotFoundError: No module named 'libpysal'"
+
+**Diagnosis:**
+Dependencies were installed to the wrong Python.
+
+**Solution:**
+1. Check where packages were installed:
+   ```bash
+   # Check system/Homebrew Python
+   python3 -c "import libpysal; print(libpysal.__file__)"
+
+   # Check QGIS Python
+   /Applications/QGIS.app/Contents/MacOS/bin/python3 -c "import libpysal; print(libpysal.__file__)"
+   ```
+
+2. If libpysal is NOT in QGIS Python, reinstall using QGIS Python Console or the automated script.
+
+### Problem: "Permission denied" or "Access is denied"
+
+**Diagnosis:**
+Insufficient permissions to write to QGIS Python's site-packages directory.
+
+**Solutions:**
+
+1. Use `--user` flag (installs to user directory):
+   ```bash
+   /Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install --user libpysal esda numba
+   ```
+
+2. Use QGIS Python Console instead (usually has correct permissions)
+
+3. Fix permissions (advanced):
+   ```bash
+   sudo chown -R $(whoami) /Applications/QGIS.app/Contents/Resources/python/
+   ```
+
+### Problem: Build errors with libpysal or esda
+
+**Symptoms:**
+```
+ERROR: Failed building wheel for libpysal
+```
+
+**Solution:**
+Use `--no-build-isolation` flag:
+```bash
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install libpysal esda --no-build-isolation
+```
+
+**Why this works:**
+These packages need to see build dependencies (like numpy, scipy) during installation. The `--no-build-isolation` flag allows them to use the already-installed versions.
+
+### Problem: Multiple QGIS installations
+
+**Diagnosis:**
+You have both QGIS LTR and QGIS Latest installed (or older versions).
+
+**Solution:**
+1. Determine which QGIS you're using:
+   ```bash
+   ls -la /Applications/ | grep -i qgis
+   ```
+
+2. Install dependencies to the correct version:
+   ```bash
+   /Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install ...
+   # or
+   /Applications/QGIS-LTR.app/Contents/MacOS/bin/python3 -m pip install ...
+   ```
+
+### Problem: Installation works but QGIS doesn't see packages
+
+**Possible causes:**
+1. **User vs system installation conflict**
+   - Check both locations: system site-packages and user site-packages
+   - Solution: Uninstall from both, reinstall to one location
+
+2. **QGIS Python Console using different Python**
+   - Verify in console: `import sys; print(sys.executable)`
+   - Should be `/Applications/QGIS.app/Contents/MacOS/bin/python3`
+
+3. **Cached imports**
+   - Solution: Fully restart QGIS (not just close/reopen)
+   - Clear Python cache: `rm -rf ~/Library/Application\ Support/QGIS/QGIS3/profiles/default/python/__pycache__`
+
+---
+
+## Advanced Scenarios
+
+### Scenario 1: Using Virtual Environments
+
+**Question:** Can I use a virtualenv or conda environment with QGIS?
+
+**Answer:** Not recommended. QGIS expects its bundled Python and pre-installed packages (PyQt5, qgis module). Using a different environment will break QGIS functionality.
+
+**Alternative:** Install packages directly to QGIS Python using the methods above.
+
+### Scenario 2: Development Workflow
+
+If you're developing plugins and want to test with development versions of dependencies:
+
+1. Clone dependency to local directory:
+   ```bash
+   cd ~/projects
+   git clone https://github.com/pysal/libpysal.git
+   ```
+
+2. Install in development mode:
+   ```bash
+   /Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install -e ~/projects/libpysal
+   ```
+
+3. Changes to the source code are immediately reflected in QGIS (after restart).
+
+### Scenario 3: Automating for Multiple Machines
+
+Create a requirements.txt file:
+
+```txt
+numpy>=1.20
+scipy>=1.7
+pandas>=1.3
+libpysal>=4.3.0
+esda>=2.4.0
+numba>=0.54
+matplotlib>=3.4
+```
+
+Install on each machine:
+```bash
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install -r requirements.txt --no-build-isolation
+```
+
+### Scenario 4: Completely Clean Reinstall
+
+If you need to start fresh:
+
+1. Uninstall packages:
+   ```bash
+   /Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip uninstall -y libpysal esda numba matplotlib scipy pandas
+   ```
+
+2. Clear pip cache:
+   ```bash
+   /Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip cache purge
+   ```
+
+3. Reinstall:
+   ```bash
+   /Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install --no-cache-dir numpy scipy pandas libpysal esda numba matplotlib --no-build-isolation
+   ```
+
+### Scenario 5: Using Homebrew to Install System Dependencies
+
+Some packages may need system libraries. Example:
+
+```bash
+# Install system dependencies via Homebrew
+brew install geos proj
+
+# Then install Python packages to QGIS Python
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install libpysal
+```
+
+---
+
+## Summary
+
+**Key Takeaways:**
+
+1. ✅ QGIS has its own Python - separate from system/Homebrew/conda Python
+2. ✅ Dependencies MUST be installed to QGIS's Python specifically
+3. ✅ Use QGIS Python Console or explicit QGIS Python path for all installations
+4. ✅ The automated scripts handle this correctly
+5. ✅ When in doubt, use the automated script from QGIS Python Console
+
+**Quick Reference:**
+
+| Method | Complexity | Reliability | Recommended For |
+|--------|------------|-------------|-----------------|
+| QGIS Python Console | Easy | Highest | Everyone, especially beginners |
+| Automated Script | Easy | High | Users who want automation |
+| Shell Script | Medium | High | Terminal users, automation |
+| One-liner | Medium | Medium | Advanced users, quick reinstall |
+| Manual | Hard | Medium | Troubleshooting, specific control |
+
+---
+
+## Additional Resources
+
+- [INSTALL_MAC.md](INSTALL_MAC.md) - Quick start guide
+- [README.md](README.md) - General installation instructions
+- [DEPENDENCIES.md](DEPENDENCIES.md) - Dependency details
+- [QGIS Python Cookbook](https://docs.qgis.org/latest/en/docs/pyqgis_developer_cookbook/) - Official PyQGIS documentation

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ pep8:
 	@echo "-----------"
 	@echo "PEP8 issues"
 	@echo "-----------"
-	@pep8 --version
-	@pep8 --repeat --ignore=E203,E121,E122,E123,E124,E125,E126,E127,E128,E402 --exclude resources_rc.py,geopublichealth/ui/  . || true
+	@pycodestyle --version
+	@pycodestyle --repeat --ignore=E203,E121,E122,E123,E124,E125,E126,E127,E128,E402 --exclude resources_rc.py,geopublichealth/ui/  . || true
 
 # LOCALES = space delimited list of iso codes to generate po files for
 # Please dont remove en here

--- a/README.md
+++ b/README.md
@@ -97,40 +97,72 @@ After installation, install Python dependencies via Python Console (see macOS in
 
 #### macOS
 
+> **Quick Start:** For a simplified guide, see [INSTALL_MAC.md](INSTALL_MAC.md)
+
 1.  Download the **[QGIS macOS Installer](https://download.qgis.org/downloads/macos/qgis-macos-pr.dmg)** from the [QGIS Download Page](https://qgis.org/download/)
 2.  Run the installer (`.dmg` file) and drag the QGIS icon to your Applications folder
 3.  **Important Security Note:** macOS may prevent QGIS from opening initially because it's from an unidentified developer. On first launch, **right-click (or Control-click)** the QGIS icon in Applications, choose **Open** from the menu, and then click the **Open** button in the confirmation dialog. You should only need to do this once.
-4.  **Install Dependencies (PySAL, Numba):** QGIS on macOS requires manual installation of Python packages within its own environment.
-    * Start QGIS
-    * Open the **Python Console** (Plugins Menu -> Python Console)
-    * Execute the following commands **one at a time** in the console prompt (`>>>`), pressing Enter after each line:
-        ```python
-        import pip
-        ```
-        ```python
-        pip.main(['install', 'pip', '--upgrade'])
-        ```
-        ```python
-        pip.main(['install', 'numpy'])
-        ```
-        ```python
-        pip.main(['install', 'scipy'])
-        ```
-        ```python
-        pip.main(['install', 'pandas'])
-        ```
-        ```python
-        pip.main(['install', 'libpysal', 'esda', '--no-build-isolation'])
-        ```
-        ```python
-        pip.main(['install', 'numba'])
-        ```
-    * Close and restart QGIS after installing these packages
-    * **Verify installation:** After restarting, open Python Console and run:
-        ```python
-        import libpysal, esda
-        print(f"libpysal {libpysal.__version__}, esda {esda.__version__} installed!")
-        ```
+4.  **Install Dependencies:** Choose one of the following methods (Option A is simplest):
+
+##### Option A: Automated Script (Recommended - Easiest)
+
+Run the automated installer script from QGIS:
+
+1.  Start QGIS
+2.  Go to **Plugins → Python Console**
+3.  Click the **"Show Editor"** button (icon in console toolbar)
+4.  Click **"Open Script"** and select `install_mac_dependencies.py` from where you downloaded/cloned GeoPublicHealth
+5.  Click **"Run Script"** button
+6.  Wait for installation to complete
+7.  Restart QGIS
+
+##### Option B: Terminal One-Liner (Fast)
+
+For users comfortable with Terminal:
+
+```bash
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install numpy scipy pandas libpysal esda numba matplotlib --no-build-isolation
+```
+
+Then restart QGIS.
+
+##### Option C: Shell Script
+
+1.  Download or clone this repository
+2.  Open Terminal
+3.  Navigate to the GeoPublicHealth folder
+4.  Run:
+    ```bash
+    bash install_mac_dependencies.sh
+    ```
+5.  Restart QGIS
+
+##### Option D: Manual Installation (Most Control)
+
+If you prefer to install packages manually one-by-one:
+
+1.  Start QGIS
+2.  Open **Python Console** (Plugins Menu → Python Console)
+3.  Run these commands **one at a time** (press Enter after each):
+    ```python
+    import pip
+    pip.main(['install', 'pip', '--upgrade'])
+    pip.main(['install', 'numpy'])
+    pip.main(['install', 'scipy'])
+    pip.main(['install', 'pandas'])
+    pip.main(['install', 'libpysal', 'esda', '--no-build-isolation'])
+    pip.main(['install', 'numba'])
+    pip.main(['install', 'matplotlib'])  # Optional
+    ```
+4.  Restart QGIS
+
+**Verify Installation:**
+
+After restarting QGIS, open Python Console and run:
+```python
+import libpysal, esda, numba
+print(f"✓ libpysal {libpysal.__version__}, esda {esda.__version__}, numba {numba.__version__}")
+```
 
 **Note:** There are no QGIS 3.40 LTR builds available on macOS. QGIS 3.44 is recommended for macOS users.
 
@@ -436,12 +468,18 @@ See [all releases](https://github.com/ePublicHealth/GeoPublicHealth/releases) fo
 
 ## Documentation
 
+### Installation
+- [INSTALL_MAC.md](INSTALL_MAC.md) - Quick Mac installation guide
+- [DEPENDENCIES.md](DEPENDENCIES.md) - Detailed dependency information and troubleshooting
+- [UNINSTALL_INSTRUCTIONS.md](UNINSTALL_INSTRUCTIONS.md) - Complete plugin reinstallation guide
+- [install_mac_dependencies.py](install_mac_dependencies.py) - Automated Mac dependency installer
+- [install_mac_dependencies.sh](install_mac_dependencies.sh) - Shell script for Mac dependencies
+- [install_matplotlib_in_qgis.py](install_matplotlib_in_qgis.py) - Script to install matplotlib in QGIS
+
+### Development
 - [AGENTS.md](AGENTS.md) - Development guide for AI coding agents
 - [RELEASE.md](RELEASE.md) - Release process and versioning
 - [CONTRIBUTING.md](CONTRIBUTING.md) - Contribution guidelines
-- [DEPENDENCIES.md](DEPENDENCIES.md) - Detailed dependency information and troubleshooting
-- [UNINSTALL_INSTRUCTIONS.md](UNINSTALL_INSTRUCTIONS.md) - Complete plugin reinstallation guide
-- [install_matplotlib_in_qgis.py](install_matplotlib_in_qgis.py) - Script to install matplotlib in QGIS
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -109,57 +109,31 @@ QGIS includes its own Python environment (located at `/Applications/QGIS.app/Con
 
 **You MUST install dependencies into QGIS's Python, NOT your system Python.** Installing to the wrong Python means QGIS won't find the packages.
 
-The methods below ensure dependencies are installed in the correct location. For technical details, see [MAC_INSTALL_TECHNICAL.md](MAC_INSTALL_TECHNICAL.md).
+**✅ RECOMMENDED: Use QGIS Python Console** - This is the most reliable method because it automatically uses the correct Python environment with no possibility of error. The alternative methods below are provided for advanced users.
+
+For technical details, see [MAC_INSTALL_TECHNICAL.md](MAC_INSTALL_TECHNICAL.md).
 
 **Installation Steps:**
 
 1.  Download the **[QGIS macOS Installer](https://download.qgis.org/downloads/macos/qgis-macos-pr.dmg)** from the [QGIS Download Page](https://qgis.org/download/)
 2.  Run the installer (`.dmg` file) and drag the QGIS icon to your Applications folder
 3.  **Important Security Note:** macOS may prevent QGIS from opening initially because it's from an unidentified developer. On first launch, **right-click (or Control-click)** the QGIS icon in Applications, choose **Open** from the menu, and then click the **Open** button in the confirmation dialog. You should only need to do this once.
-4.  **Install Dependencies:** Choose one of the following methods (Option A is recommended as it automatically uses the correct Python):
+4.  **Install Dependencies using QGIS Python Console (RECOMMENDED):**
 
-##### Option A: Automated Script (Recommended - Easiest)
+    **Method 1: Automated Script** (Easiest - just click "Run")
 
-Run the automated installer script from QGIS:
+    1.  Start QGIS
+    2.  Go to **Plugins → Python Console**
+    3.  Click the **"Show Editor"** button (icon in console toolbar)
+    4.  Click **"Open Script"** and select `install_dependencies_console.py`
+    5.  Click **"Run Script"** button
+    6.  Wait for installation to complete (you'll see progress in the console)
+    7.  Restart QGIS
 
-1.  Start QGIS
-2.  Go to **Plugins → Python Console**
-3.  Click the **"Show Editor"** button (icon in console toolbar)
-4.  Click **"Open Script"** and select `install_mac_dependencies.py` from where you downloaded/cloned GeoPublicHealth
-5.  Click **"Run Script"** button
-6.  Wait for installation to complete
-7.  Restart QGIS
+    **Method 2: Manual Console Commands** (More control)
 
-##### Option B: Terminal One-Liner (Fast)
+    Run these commands **one at a time** in QGIS Python Console (press Enter after each):
 
-For users comfortable with Terminal, copy and paste this **exact command** (note the full path to QGIS Python):
-
-```bash
-/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install numpy scipy pandas libpysal esda numba matplotlib --no-build-isolation
-```
-
-⚠️ **Important:** Use the full QGIS Python path shown above. Do NOT use just `python3` or `pip install` - those will install to the wrong Python!
-
-Then restart QGIS.
-
-##### Option C: Shell Script
-
-1.  Download or clone this repository
-2.  Open Terminal
-3.  Navigate to the GeoPublicHealth folder
-4.  Run:
-    ```bash
-    bash install_mac_dependencies.sh
-    ```
-5.  Restart QGIS
-
-##### Option D: Manual Installation (Most Control)
-
-If you prefer to install packages manually one-by-one:
-
-1.  Start QGIS
-2.  Open **Python Console** (Plugins Menu → Python Console)
-3.  Run these commands **one at a time** (press Enter after each):
     ```python
     import pip
     pip.main(['install', 'pip', '--upgrade'])
@@ -168,9 +142,32 @@ If you prefer to install packages manually one-by-one:
     pip.main(['install', 'pandas'])
     pip.main(['install', 'libpysal', 'esda', '--no-build-isolation'])
     pip.main(['install', 'numba'])
-    pip.main(['install', 'matplotlib'])  # Optional
+    pip.main(['install', 'matplotlib'])  # Optional - for plotting
     ```
-4.  Restart QGIS
+
+    Then restart QGIS.
+
+<details>
+<summary><b>Alternative Methods (Advanced Users Only)</b></summary>
+
+These methods require Terminal and are more error-prone. **The QGIS Python Console methods above are recommended.**
+
+**Terminal One-Liner:**
+
+```bash
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install numpy scipy pandas libpysal esda numba matplotlib --no-build-isolation
+```
+
+⚠️ **Critical:** Must use the exact QGIS Python path shown. Do NOT use just `python3` - that uses the wrong Python!
+
+**Shell Script:**
+
+```bash
+cd /path/to/GeoPublicHealth
+bash install_mac_dependencies.sh
+```
+
+</details>
 
 **Verify Installation:**
 
@@ -489,9 +486,12 @@ See [all releases](https://github.com/ePublicHealth/GeoPublicHealth/releases) fo
 - [MAC_INSTALL_TECHNICAL.md](MAC_INSTALL_TECHNICAL.md) - Technical guide: Python environments, advanced troubleshooting
 - [DEPENDENCIES.md](DEPENDENCIES.md) - Detailed dependency information and troubleshooting
 - [UNINSTALL_INSTRUCTIONS.md](UNINSTALL_INSTRUCTIONS.md) - Complete plugin reinstallation guide
-- [install_mac_dependencies.py](install_mac_dependencies.py) - Automated Mac dependency installer
-- [install_mac_dependencies.sh](install_mac_dependencies.sh) - Shell script for Mac dependencies
-- [install_matplotlib_in_qgis.py](install_matplotlib_in_qgis.py) - Script to install matplotlib in QGIS
+
+**Installation Scripts:**
+- [install_dependencies_console.py](install_dependencies_console.py) - **RECOMMENDED:** Console-first installer (paste/run in QGIS)
+- [install_mac_dependencies.py](install_mac_dependencies.py) - Advanced: Terminal/Console hybrid installer
+- [install_mac_dependencies.sh](install_mac_dependencies.sh) - Advanced: Shell script for Terminal
+- [install_matplotlib_in_qgis.py](install_matplotlib_in_qgis.py) - Optional: Install matplotlib only
 
 ### Development
 - [AGENTS.md](AGENTS.md) - Development guide for AI coding agents

--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ For technical details, see [MAC_INSTALL_TECHNICAL.md](MAC_INSTALL_TECHNICAL.md).
     subprocess.run([sys.executable, "-m", "pip", "install", "numpy"])
     subprocess.run([sys.executable, "-m", "pip", "install", "scipy"])
     subprocess.run([sys.executable, "-m", "pip", "install", "pandas"])
+    subprocess.run([sys.executable, "-m", "pip", "install", "numba"])  # Install before libpysal/esda
     subprocess.run([sys.executable, "-m", "pip", "install", "libpysal", "esda", "--no-build-isolation"])
-    subprocess.run([sys.executable, "-m", "pip", "install", "numba"])
     subprocess.run([sys.executable, "-m", "pip", "install", "matplotlib"])  # Optional
     ```
 
@@ -157,7 +157,7 @@ These methods require Terminal and are more error-prone. **The QGIS Python Conso
 **Terminal One-Liner:**
 
 ```bash
-/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install numpy scipy pandas libpysal esda numba matplotlib --no-build-isolation
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install numpy scipy pandas numba libpysal esda matplotlib --no-build-isolation
 ```
 
 ⚠️ **Critical:** Must use the exact QGIS Python path shown. Do NOT use just `python3` - that uses the wrong Python!
@@ -178,6 +178,21 @@ QGIS_PYTHON="/Applications/QGIS-LTR.app/Contents/MacOS/bin/python3" bash install
 # Python script non-interactive mode
 /Applications/QGIS.app/Contents/MacOS/bin/python3 install_mac_dependencies.py --yes --log /tmp/install.log
 ```
+
+**For reproducible installations (pinned versions):**
+
+```bash
+# Use requirements file with tested, pinned versions
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install -r requirements-mac.txt --no-build-isolation
+```
+
+Or from QGIS Python Console:
+```python
+import subprocess, sys
+subprocess.run([sys.executable, "-m", "pip", "install", "-r", "requirements-mac.txt", "--no-build-isolation"])
+```
+
+**Note:** The automated scripts install latest versions. For production or reproducible installs, use `requirements-mac.txt` which contains tested, compatible versions. See [MAC_INSTALL_TECHNICAL.md](MAC_INSTALL_TECHNICAL.md) for details.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -135,15 +135,17 @@ For technical details, see [MAC_INSTALL_TECHNICAL.md](MAC_INSTALL_TECHNICAL.md).
     Run these commands **one at a time** in QGIS Python Console (press Enter after each):
 
     ```python
-    import pip
-    pip.main(['install', 'pip', '--upgrade'])
-    pip.main(['install', 'numpy'])
-    pip.main(['install', 'scipy'])
-    pip.main(['install', 'pandas'])
-    pip.main(['install', 'libpysal', 'esda', '--no-build-isolation'])
-    pip.main(['install', 'numba'])
-    pip.main(['install', 'matplotlib'])  # Optional - for plotting
+    import subprocess, sys
+    subprocess.run([sys.executable, "-m", "pip", "install", "--upgrade", "pip"])
+    subprocess.run([sys.executable, "-m", "pip", "install", "numpy"])
+    subprocess.run([sys.executable, "-m", "pip", "install", "scipy"])
+    subprocess.run([sys.executable, "-m", "pip", "install", "pandas"])
+    subprocess.run([sys.executable, "-m", "pip", "install", "libpysal", "esda", "--no-build-isolation"])
+    subprocess.run([sys.executable, "-m", "pip", "install", "numba"])
+    subprocess.run([sys.executable, "-m", "pip", "install", "matplotlib"])  # Optional
     ```
+
+    **Note:** We use `subprocess.run([sys.executable, "-m", "pip", ...])` instead of `pip.main()` because `pip.main()` is not a stable public API.
 
     Then restart QGIS.
 
@@ -165,6 +167,16 @@ These methods require Terminal and are more error-prone. **The QGIS Python Conso
 ```bash
 cd /path/to/GeoPublicHealth
 bash install_mac_dependencies.sh
+```
+
+**For QGIS-LTR or other QGIS installations:**
+
+```bash
+# Shell script with custom QGIS path
+QGIS_PYTHON="/Applications/QGIS-LTR.app/Contents/MacOS/bin/python3" bash install_mac_dependencies.sh
+
+# Python script non-interactive mode
+/Applications/QGIS.app/Contents/MacOS/bin/python3 install_mac_dependencies.py --yes --log /tmp/install.log
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -99,10 +99,24 @@ After installation, install Python dependencies via Python Console (see macOS in
 
 > **Quick Start:** For a simplified guide, see [INSTALL_MAC.md](INSTALL_MAC.md)
 
+**⚠️ Important: Understanding Python Environments on Mac**
+
+QGIS includes its own Python environment (located at `/Applications/QGIS.app/Contents/MacOS/bin/python3`). This is **separate** from:
+- macOS system Python (`/usr/bin/python3`)
+- Homebrew Python (`/opt/homebrew/bin/python3` or `/usr/local/bin/python3`)
+- Anaconda/Miniconda Python
+- Any other Python installation
+
+**You MUST install dependencies into QGIS's Python, NOT your system Python.** Installing to the wrong Python means QGIS won't find the packages.
+
+The methods below ensure dependencies are installed in the correct location. For technical details, see [MAC_INSTALL_TECHNICAL.md](MAC_INSTALL_TECHNICAL.md).
+
+**Installation Steps:**
+
 1.  Download the **[QGIS macOS Installer](https://download.qgis.org/downloads/macos/qgis-macos-pr.dmg)** from the [QGIS Download Page](https://qgis.org/download/)
 2.  Run the installer (`.dmg` file) and drag the QGIS icon to your Applications folder
 3.  **Important Security Note:** macOS may prevent QGIS from opening initially because it's from an unidentified developer. On first launch, **right-click (or Control-click)** the QGIS icon in Applications, choose **Open** from the menu, and then click the **Open** button in the confirmation dialog. You should only need to do this once.
-4.  **Install Dependencies:** Choose one of the following methods (Option A is simplest):
+4.  **Install Dependencies:** Choose one of the following methods (Option A is recommended as it automatically uses the correct Python):
 
 ##### Option A: Automated Script (Recommended - Easiest)
 
@@ -118,11 +132,13 @@ Run the automated installer script from QGIS:
 
 ##### Option B: Terminal One-Liner (Fast)
 
-For users comfortable with Terminal:
+For users comfortable with Terminal, copy and paste this **exact command** (note the full path to QGIS Python):
 
 ```bash
 /Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install numpy scipy pandas libpysal esda numba matplotlib --no-build-isolation
 ```
+
+⚠️ **Important:** Use the full QGIS Python path shown above. Do NOT use just `python3` or `pip install` - those will install to the wrong Python!
 
 Then restart QGIS.
 
@@ -470,6 +486,7 @@ See [all releases](https://github.com/ePublicHealth/GeoPublicHealth/releases) fo
 
 ### Installation
 - [INSTALL_MAC.md](INSTALL_MAC.md) - Quick Mac installation guide
+- [MAC_INSTALL_TECHNICAL.md](MAC_INSTALL_TECHNICAL.md) - Technical guide: Python environments, advanced troubleshooting
 - [DEPENDENCIES.md](DEPENDENCIES.md) - Detailed dependency information and troubleshooting
 - [UNINSTALL_INSTRUCTIONS.md](UNINSTALL_INSTRUCTIONS.md) - Complete plugin reinstallation guide
 - [install_mac_dependencies.py](install_mac_dependencies.py) - Automated Mac dependency installer

--- a/install_dependencies_console.py
+++ b/install_dependencies_console.py
@@ -93,18 +93,20 @@ def run_pip_install(packages, timeout=None):
 
 # Define packages to install
 # Format: (name, pip_args, description, required)
+# IMPORTANT: Order matters! numba must be installed before libpysal/esda
+# because those packages may use numba during build/installation
 packages = [
     ("pip", ["pip", "--upgrade"], "Package installer", True),
     ("numpy", ["numpy"], "Numerical computing", True),
     ("scipy", ["scipy"], "Scientific computing", True),
     ("pandas", ["pandas"], "Data analysis", True),
+    ("numba", ["numba"], "Performance optimization", True),
     (
         "libpysal & esda",
         ["libpysal", "esda", "--no-build-isolation"],
         "Spatial analysis",
         True,
     ),
-    ("numba", ["numba"], "Performance optimization", True),
     ("matplotlib", ["matplotlib"], "Plotting and visualization", False),
 ]
 
@@ -219,7 +221,9 @@ else:
     print("4. Report the issue with the log file:")
     print("   https://github.com/ePublicHealth/GeoPublicHealth/issues")
     print()
-    # Exit with error code so automation can detect failure
-    sys.exit(1)
+    print("NOTE: Installation incomplete. Please address the issues above.")
+    # Note: We don't call sys.exit() here because when run in QGIS Python Console,
+    # it would raise SystemExit and show a stack trace, confusing users.
+    # The script simply finishes with the error message above.
 
 print("=" * 70)

--- a/install_dependencies_console.py
+++ b/install_dependencies_console.py
@@ -1,10 +1,32 @@
+# -*- coding: utf-8 -*-
 """
+/***************************************************************************
+
+                                 GeoPublicHealth
+                                 A QGIS plugin
+
+                              -------------------
+        begin                : 2026-01-24
+        copyright            : (C) 2026 by Manuel Vidaurre
+        email                : manuel.vidaurre@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 GeoPublicHealth Dependency Installer for QGIS Python Console
 
 RECOMMENDED INSTALLATION METHOD - Run this from QGIS Python Console.
 
-This script is designed to be run directly in the QGIS Python Console, which
-automatically ensures dependencies are installed to the correct Python environment.
+This script is designed to be run directly in the QGIS Python Console,
+which automatically ensures dependencies are installed to the correct
+Python environment.
 
 USAGE:
 1. Open QGIS
@@ -15,7 +37,8 @@ USAGE:
 6. Wait for installation to complete
 7. Restart QGIS
 
-Or paste the code directly into the console (copy everything below the instructions).
+Or paste the code directly into the console (copy everything below the
+instructions).
 
 Why this method is best:
 - Automatically uses QGIS's Python (no environment confusion)
@@ -58,21 +81,22 @@ def run_pip_install(packages, timeout=None):
     Run pip install using subprocess for stability.
 
     Note: We use subprocess.run with sys.executable instead of pip.main()
-    because pip.main() is not a stable public API and can break with pip upgrades.
+    because pip.main() is not a stable public API and can break with pip
+    upgrades.
     """
     cmd = [sys.executable, "-m", "pip", "install"] + packages
 
     with open(log_path, "a", encoding="utf-8") as log:
-        log.write(f"\n{'='*70}\n")
+        log.write(f"\n{'=' * 70}\n")
         log.write(f">>> {' '.join(cmd)}\n")
-        log.write(f"{'='*70}\n")
+        log.write(f"{'=' * 70}\n")
 
         try:
             proc = subprocess.run(
                 cmd,
                 capture_output=True,
                 text=True,
-                timeout=timeout
+                timeout=timeout,
             )
 
             # Write full output to log
@@ -127,7 +151,7 @@ failed = []
 for name, pip_args, desc, required in packages:
     print(f"Installing {name}...", end=" ", flush=True)
 
-    rc, stdout, stderr = run_pip_install(pip_args, timeout=600)  # 10 minute timeout
+    rc, stdout, stderr = run_pip_install(pip_args, timeout=600)
 
     if rc == 0:
         print("✓")
@@ -186,9 +210,10 @@ print()
 # Check optional
 try:
     import matplotlib
+
     print(f"✓ matplotlib {matplotlib.__version__} - Plotting (optional)")
 except ImportError:
-    print("○ matplotlib not installed - Plotting features will be disabled (optional)")
+    print("matplotlib not installed - plotting disabled (optional)")
 
 print()
 print("=" * 70)
@@ -222,8 +247,9 @@ else:
     print("   https://github.com/ePublicHealth/GeoPublicHealth/issues")
     print()
     print("NOTE: Installation incomplete. Please address the issues above.")
-    # Note: We don't call sys.exit() here because when run in QGIS Python Console,
-    # it would raise SystemExit and show a stack trace, confusing users.
+    # Note: We don't call sys.exit() here because when run in QGIS Python
+    # Console it would raise SystemExit and show a stack trace that confuses
+    # users.
     # The script simply finishes with the error message above.
 
 print("=" * 70)

--- a/install_dependencies_console.py
+++ b/install_dependencies_console.py
@@ -1,0 +1,184 @@
+"""
+GeoPublicHealth Dependency Installer for QGIS Python Console
+
+RECOMMENDED INSTALLATION METHOD - Run this from QGIS Python Console.
+
+This script is designed to be run directly in the QGIS Python Console, which
+automatically ensures dependencies are installed to the correct Python environment.
+
+USAGE:
+1. Open QGIS
+2. Go to Plugins → Python Console
+3. Click "Show Editor" button (icon in toolbar)
+4. Click "Open Script" and select this file
+5. Click "Run Script" button
+6. Wait for installation to complete
+7. Restart QGIS
+
+Or paste the code directly into the console (copy everything below the instructions).
+
+Why this method is best:
+- Automatically uses QGIS's Python (no environment confusion)
+- No need to find or type QGIS Python path
+- Works regardless of other Python installations on your Mac
+- No Terminal knowledge required
+- Can't accidentally install to wrong Python
+"""
+
+print("=" * 70)
+print("GeoPublicHealth Dependency Installer")
+print("=" * 70)
+print()
+print("Installing dependencies for QGIS Python environment...")
+print()
+
+# Import pip
+try:
+    import pip
+except ImportError:
+    print("ERROR: pip not found. This should not happen in QGIS.")
+    print("Please report this issue.")
+    raise
+
+# Check Python environment
+import sys
+print(f"Python: {sys.executable}")
+if "QGIS.app" in sys.executable or "qgis" in sys.executable.lower():
+    print("✓ Running in QGIS Python environment (correct!)")
+else:
+    print("⚠️  Warning: This may not be QGIS Python")
+    print("   Recommended: Run this from QGIS Python Console instead")
+print()
+
+# Define packages to install
+# Format: (name, pip_args, description, required)
+packages = [
+    ("pip", ["pip", "--upgrade"], "Package installer", True),
+    ("numpy", ["numpy"], "Numerical computing", True),
+    ("scipy", ["scipy"], "Scientific computing", True),
+    ("pandas", ["pandas"], "Data analysis", True),
+    (
+        "libpysal & esda",
+        ["libpysal", "esda", "--no-build-isolation"],
+        "Spatial analysis",
+        True,
+    ),
+    ("numba", ["numba"], "Performance optimization", True),
+    ("matplotlib", ["matplotlib"], "Plotting and visualization", False),
+]
+
+print("The following packages will be installed:")
+for name, _, desc, required in packages:
+    status = "Required" if required else "Optional"
+    print(f"  • {name}: {desc} ({status})")
+print()
+
+print("=" * 70)
+print("Starting installation...")
+print("=" * 70)
+print()
+
+installed = []
+failed = []
+skipped = []
+
+for name, pip_args, desc, required in packages:
+    print(f"Installing {name}...", end=" ")
+
+    try:
+        # Use pip.main() to install - this is the most reliable method
+        # when running inside QGIS Python Console
+        result = pip.main(["install"] + pip_args)
+
+        if result == 0:
+            print("✓")
+            installed.append(name)
+        else:
+            print("✗")
+            failed.append(name)
+            if required:
+                print(f"  Warning: {name} is required for the plugin to work")
+
+    except Exception as e:
+        print(f"✗ Error: {e}")
+        failed.append(name)
+        if required:
+            print(f"  Warning: {name} is required for the plugin to work")
+
+print()
+print("=" * 70)
+print("Installation Summary")
+print("=" * 70)
+print()
+
+if installed:
+    print(f"✓ Successfully installed ({len(installed)}):")
+    for name in installed:
+        print(f"  • {name}")
+    print()
+
+if failed:
+    print(f"✗ Failed to install ({len(failed)}):")
+    for name in failed:
+        print(f"  • {name}")
+    print()
+
+# Verify critical dependencies
+print("=" * 70)
+print("Verifying Required Dependencies")
+print("=" * 70)
+print()
+
+critical_packages = {
+    "libpysal": "Spatial analysis library",
+    "esda": "Exploratory spatial data analysis",
+    "numba": "Performance optimization",
+}
+
+all_critical_ok = True
+for module, description in critical_packages.items():
+    try:
+        mod = __import__(module)
+        version = getattr(mod, "__version__", "unknown")
+        print(f"✓ {module} {version} - {description}")
+    except ImportError:
+        print(f"✗ {module} NOT FOUND - {description}")
+        all_critical_ok = False
+
+print()
+
+# Check optional
+try:
+    import matplotlib
+
+    print(f"✓ matplotlib {matplotlib.__version__} - Plotting (optional)")
+except ImportError:
+    print("○ matplotlib not installed - Plotting features will be disabled (optional)")
+
+print()
+print("=" * 70)
+
+if all_critical_ok:
+    print("SUCCESS!")
+    print()
+    print("All required dependencies are installed.")
+    print()
+    print("Next steps:")
+    print("1. Restart QGIS completely (close and reopen)")
+    print("2. Install the GeoPublicHealth plugin:")
+    print("   - Go to Plugins → Manage and Install Plugins")
+    print("   - Search for 'geopublichealth'")
+    print("   - Click Install")
+    print("3. Start using GeoPublicHealth!")
+else:
+    print("INSTALLATION INCOMPLETE")
+    print()
+    print("Some required dependencies failed to install.")
+    print()
+    print("Troubleshooting:")
+    print("1. Try running this script again")
+    print("2. Close and restart QGIS, then run the script again")
+    print("3. See MAC_INSTALL_TECHNICAL.md for advanced troubleshooting")
+    print("4. Report the issue: https://github.com/ePublicHealth/GeoPublicHealth/issues")
+
+print("=" * 70)

--- a/install_mac_dependencies.py
+++ b/install_mac_dependencies.py
@@ -3,9 +3,16 @@ Installation script for GeoPublicHealth dependencies on macOS.
 
 This script installs all required dependencies for the GeoPublicHealth QGIS plugin.
 
+IMPORTANT: This script MUST be run using QGIS's Python, not your system Python.
+           QGIS has its own isolated Python environment separate from:
+           - macOS system Python (/usr/bin/python3)
+           - Homebrew Python (/opt/homebrew/bin/python3 or /usr/local/bin/python3)
+           - Anaconda/Miniconda Python
+           - Any other Python installation
+
 USAGE:
 
-Method 1 - Run from QGIS Python Console (Recommended):
+Method 1 - Run from QGIS Python Console (RECOMMENDED - Always uses correct Python):
 1. Open QGIS
 2. Go to Plugins > Python Console
 3. Click the "Show Editor" button (icon in console toolbar)
@@ -13,8 +20,10 @@ Method 1 - Run from QGIS Python Console (Recommended):
 5. Click "Run Script" button
 6. Restart QGIS when complete
 
-Method 2 - Run from Terminal:
+Method 2 - Run from Terminal (ONLY if you use the full QGIS Python path):
    /Applications/QGIS.app/Contents/MacOS/bin/python3 install_mac_dependencies.py
+
+   WARNING: Do NOT run with just "python3" or "python" - this will use the wrong Python!
 
 Method 3 - Paste into QGIS Python Console:
    Copy and paste the entire script into the console
@@ -22,6 +31,17 @@ Method 3 - Paste into QGIS Python Console:
 
 import subprocess
 import sys
+import os
+
+
+def verify_qgis_python():
+    """Verify we're running with QGIS Python, not system Python."""
+    python_exe = sys.executable
+
+    # Check if this looks like QGIS Python
+    is_qgis_python = "QGIS.app" in python_exe or "qgis" in python_exe.lower()
+
+    return is_qgis_python, python_exe
 
 
 def install_dependencies():
@@ -31,10 +51,33 @@ def install_dependencies():
     print("GeoPublicHealth macOS Dependency Installer")
     print("=" * 70)
 
-    # Get the current Python executable
-    python_exe = sys.executable
-    print(f"\nUsing Python: {python_exe}")
-    print(f"Python version: {sys.version}")
+    # Verify we're using QGIS Python
+    is_qgis_python, python_exe = verify_qgis_python()
+
+    print(f"\nPython executable: {python_exe}")
+    print(f"Python version: {sys.version.split()[0]}")
+
+    if is_qgis_python:
+        print("✓ Running with QGIS Python (correct!)")
+    else:
+        print("\n" + "!" * 70)
+        print("⚠️  WARNING: This may NOT be QGIS's Python!")
+        print("!" * 70)
+        print("\nYou appear to be running with system/Homebrew/Anaconda Python.")
+        print("Dependencies installed here will NOT be available in QGIS.")
+        print("\nQGIS Python is usually located at:")
+        print("  /Applications/QGIS.app/Contents/MacOS/bin/python3")
+        print("\nRECOMMENDED: Run this script from QGIS Python Console instead.")
+        print("See installation instructions in README.md or INSTALL_MAC.md")
+        print("\n" + "!" * 70)
+
+        response = input("\nContinue anyway? (yes/no): ").strip().lower()
+        if response not in ['yes', 'y']:
+            print("\nInstallation cancelled. Please run from QGIS Python Console.")
+            return False
+        print("\nProceeding with current Python (you have been warned)...")
+
+    print("\n" + "=" * 70)
 
     # Define dependencies to install
     # Order matters: install base packages first, then those that depend on them

--- a/install_mac_dependencies.py
+++ b/install_mac_dependencies.py
@@ -154,18 +154,19 @@ def install_dependencies():
     print("\n" + "=" * 70)
 
     # Define dependencies to install
-    # Order matters: install base packages first, then those that depend on them
+    # IMPORTANT: Order matters! numba must be installed before libpysal/esda
+    # because those packages may use numba during build/installation
     dependencies = [
         ("pip", ["pip", "--upgrade"], "Package installer"),
         ("numpy", ["numpy"], "Numerical computing"),
         ("scipy", ["scipy"], "Scientific computing"),
         ("pandas", ["pandas"], "Data analysis"),
+        ("numba", ["numba"], "Performance optimization (Required)"),
         (
             "libpysal & esda",
             ["libpysal", "esda", "--no-build-isolation"],
             "Spatial analysis (Required)",
         ),
-        ("numba", ["numba"], "Performance optimization (Required)"),
         ("matplotlib", ["matplotlib"], "Plotting (Optional)"),
     ]
 
@@ -265,7 +266,11 @@ def install_dependencies():
     print("VERIFYING REQUIRED DEPENDENCIES")
     print("=" * 70)
 
-    critical = {"libpysal": "Spatial analysis", "numba": "Performance optimization"}
+    critical = {
+        "libpysal": "Spatial analysis",
+        "esda": "Exploratory spatial data analysis",
+        "numba": "Performance optimization"
+    }
 
     all_critical_ok = True
     for module, description in critical.items():

--- a/install_mac_dependencies.py
+++ b/install_mac_dependencies.py
@@ -1,0 +1,185 @@
+"""
+Installation script for GeoPublicHealth dependencies on macOS.
+
+This script installs all required dependencies for the GeoPublicHealth QGIS plugin.
+
+USAGE:
+
+Method 1 - Run from QGIS Python Console (Recommended):
+1. Open QGIS
+2. Go to Plugins > Python Console
+3. Click the "Show Editor" button (icon in console toolbar)
+4. Open this file (install_mac_dependencies.py)
+5. Click "Run Script" button
+6. Restart QGIS when complete
+
+Method 2 - Run from Terminal:
+   /Applications/QGIS.app/Contents/MacOS/bin/python3 install_mac_dependencies.py
+
+Method 3 - Paste into QGIS Python Console:
+   Copy and paste the entire script into the console
+"""
+
+import subprocess
+import sys
+
+
+def install_dependencies():
+    """Install all required dependencies for GeoPublicHealth on macOS."""
+
+    print("=" * 70)
+    print("GeoPublicHealth macOS Dependency Installer")
+    print("=" * 70)
+
+    # Get the current Python executable
+    python_exe = sys.executable
+    print(f"\nUsing Python: {python_exe}")
+    print(f"Python version: {sys.version}")
+
+    # Define dependencies to install
+    # Order matters: install base packages first, then those that depend on them
+    dependencies = [
+        ("pip", ["pip", "--upgrade"], "Package installer"),
+        ("numpy", ["numpy"], "Numerical computing"),
+        ("scipy", ["scipy"], "Scientific computing"),
+        ("pandas", ["pandas"], "Data analysis"),
+        (
+            "libpysal & esda",
+            ["libpysal", "esda", "--no-build-isolation"],
+            "Spatial analysis (Required)",
+        ),
+        ("numba", ["numba"], "Performance optimization (Required)"),
+        ("matplotlib", ["matplotlib"], "Plotting (Optional)"),
+    ]
+
+    print("\nThe following packages will be installed:")
+    for name, _, description in dependencies:
+        print(f"  • {name}: {description}")
+
+    print("\n" + "=" * 70)
+    print("Starting installation...")
+    print("=" * 70)
+
+    installed = []
+    failed = []
+
+    for name, packages, description in dependencies:
+        print(f"\n[{len(installed) + len(failed) + 1}/{len(dependencies)}] Installing {name}...")
+        print("-" * 70)
+
+        try:
+            # Build the pip install command
+            cmd = [python_exe, "-m", "pip", "install"] + packages
+
+            print(f"Running: pip install {' '.join(packages)}")
+
+            # Run pip install
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=300  # 5 minute timeout
+            )
+
+            # Show output
+            if result.stdout:
+                # Only show last few lines to avoid clutter
+                lines = result.stdout.strip().split("\n")
+                for line in lines[-5:]:
+                    if line.strip():
+                        print(f"  {line}")
+
+            if result.returncode == 0:
+                print(f"✓ {name} installed successfully")
+                installed.append(name)
+            else:
+                print(f"✗ {name} installation failed")
+                if result.stderr:
+                    print("Error details:")
+                    for line in result.stderr.strip().split("\n")[-5:]:
+                        if line.strip():
+                            print(f"  {line}")
+                failed.append(name)
+
+        except subprocess.TimeoutExpired:
+            print(f"✗ {name} installation timed out (took more than 5 minutes)")
+            failed.append(name)
+        except Exception as e:
+            print(f"✗ Error installing {name}: {str(e)}")
+            failed.append(name)
+
+    # Summary
+    print("\n" + "=" * 70)
+    print("INSTALLATION SUMMARY")
+    print("=" * 70)
+
+    if installed:
+        print(f"\n✓ Successfully installed ({len(installed)}):")
+        for name in installed:
+            print(f"  • {name}")
+
+    if failed:
+        print(f"\n✗ Failed to install ({len(failed)}):")
+        for name in failed:
+            print(f"  • {name}")
+
+    # Verify critical dependencies
+    print("\n" + "=" * 70)
+    print("VERIFYING REQUIRED DEPENDENCIES")
+    print("=" * 70)
+
+    critical = {"libpysal": "Spatial analysis", "numba": "Performance optimization"}
+
+    all_critical_ok = True
+    for module, description in critical.items():
+        try:
+            __import__(module)
+            print(f"✓ {module} is available - {description}")
+        except ImportError:
+            print(f"✗ {module} is NOT available - {description}")
+            all_critical_ok = False
+
+    # Check optional dependencies
+    print("\nOptional dependencies:")
+    try:
+        import matplotlib
+
+        print(f"✓ matplotlib is available (version {matplotlib.__version__})")
+    except ImportError:
+        print("○ matplotlib is not available (plotting features will be disabled)")
+
+    # Final message
+    print("\n" + "=" * 70)
+    if all_critical_ok and not failed:
+        print("SUCCESS! All dependencies installed successfully.")
+        print("\nNext steps:")
+        print("1. Restart QGIS for changes to take effect")
+        print("2. Install the GeoPublicHealth plugin from Plugins menu")
+        print("3. Start using GeoPublicHealth!")
+    elif all_critical_ok:
+        print("PARTIAL SUCCESS - Core dependencies are installed.")
+        print(
+            "\nSome optional packages failed, but the plugin should work for basic features."
+        )
+        print("\nNext steps:")
+        print("1. Restart QGIS for changes to take effect")
+        print("2. Install the GeoPublicHealth plugin from Plugins menu")
+    else:
+        print("INSTALLATION INCOMPLETE")
+        print(
+            "\nSome required dependencies failed to install. Please try manual installation:"
+        )
+        print("\nOption 1 - Terminal (recommended):")
+        print(
+            "  /Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install libpysal esda numba --no-build-isolation"
+        )
+        print("\nOption 2 - QGIS Python Console (one command at a time):")
+        print("  import pip")
+        print("  pip.main(['install', 'libpysal', 'esda', '--no-build-isolation'])")
+        print("  pip.main(['install', 'numba'])")
+
+    print("=" * 70)
+
+    return all_critical_ok
+
+
+if __name__ == "__main__":
+    # Run the installation
+    install_dependencies()

--- a/install_mac_dependencies.py
+++ b/install_mac_dependencies.py
@@ -1,18 +1,42 @@
+# -*- coding: utf-8 -*-
 """
+/***************************************************************************
+
+                                 GeoPublicHealth
+                                 A QGIS plugin
+
+                              -------------------
+        begin                : 2026-01-24
+        copyright            : (C) 2026 by Manuel Vidaurre
+        email                : manuel.vidaurre@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 Installation script for GeoPublicHealth dependencies on macOS.
 
-This script installs all required dependencies for the GeoPublicHealth QGIS plugin.
+This script installs all required dependencies for the GeoPublicHealth QGIS
+plugin.
 
 IMPORTANT: This script MUST be run using QGIS's Python, not your system Python.
            QGIS has its own isolated Python environment separate from:
            - macOS system Python (/usr/bin/python3)
-           - Homebrew Python (/opt/homebrew/bin/python3 or /usr/local/bin/python3)
+           - Homebrew Python (/opt/homebrew/bin/python3 or
+             /usr/local/bin/python3)
            - Anaconda/Miniconda Python
            - Any other Python installation
 
 USAGE:
 
-Method 1 - Run from QGIS Python Console (RECOMMENDED - Always uses correct Python):
+Method 1 - Run from QGIS Python Console (RECOMMENDED - Always uses correct
+Python):
 1. Open QGIS
 2. Go to Plugins > Python Console
 3. Click the "Show Editor" button (icon in console toolbar)
@@ -21,7 +45,8 @@ Method 1 - Run from QGIS Python Console (RECOMMENDED - Always uses correct Pytho
 6. Restart QGIS when complete
 
 Method 2 - Run from Terminal (ONLY if you use the full QGIS Python path):
-   /Applications/QGIS.app/Contents/MacOS/bin/python3 install_mac_dependencies.py
+   /Applications/QGIS.app/Contents/MacOS/bin/python3
+   install_mac_dependencies.py
 
    Optional arguments:
    --python-path PATH    Override Python executable path
@@ -30,9 +55,11 @@ Method 2 - Run from Terminal (ONLY if you use the full QGIS Python path):
    --log PATH            Log file path (default: auto-generated)
 
    Example for automation:
-   /Applications/QGIS.app/Contents/MacOS/bin/python3 install_mac_dependencies.py --yes --log /tmp/install.log
+   /Applications/QGIS.app/Contents/MacOS/bin/python3
+   install_mac_dependencies.py --yes --log /tmp/install.log
 
-   WARNING: Do NOT run with just "python3" or "python" - this will use the wrong Python!
+   WARNING: Do NOT run with just "python3" or "python".
+   This will use the wrong Python.
 
 Method 3 - Paste into QGIS Python Console:
    Copy and paste the entire script into the console
@@ -40,7 +67,6 @@ Method 3 - Paste into QGIS Python Console:
 
 import subprocess
 import sys
-import os
 import argparse
 import datetime
 from pathlib import Path
@@ -64,32 +90,35 @@ Examples:
   /Applications/QGIS.app/Contents/MacOS/bin/python3 install_mac_dependencies.py
 
   # Non-interactive mode for automation:
-  /Applications/QGIS.app/Contents/MacOS/bin/python3 install_mac_dependencies.py --yes --log /tmp/install.log
+  /Applications/QGIS.app/Contents/MacOS/bin/python3 install_mac_dependencies.py
+  --yes --log /tmp/install.log
 
   # Override QGIS Python path:
-  python3 install_mac_dependencies.py --python-path /Applications/QGIS-LTR.app/Contents/MacOS/bin/python3
-        """
+  python3 install_mac_dependencies.py --python-path
+  /Applications/QGIS-LTR.app/Contents/MacOS/bin/python3
+        """,
     )
 
     parser.add_argument(
         "--python-path",
         help="Path to Python executable to use (default: current Python)",
-        default=sys.executable
+        default=sys.executable,
     )
     parser.add_argument(
-        "--yes", "-y",
+        "--yes",
+        "-y",
         action="store_true",
-        help="Skip interactive prompts (assume yes)"
+        help="Skip interactive prompts (assume yes)",
     )
     parser.add_argument(
         "--timeout",
         type=int,
         default=None,
-        help="Timeout in seconds for each pip install (default: none)"
+        help="Timeout in seconds for each pip install (default: none)",
     )
     parser.add_argument(
         "--log",
-        help="Path to log file (default: ./geopublichealth_install_TIMESTAMP.log)"
+        help=("Log file path (default: geopublichealth_install_<ts>.log)"),
     )
 
     return parser.parse_args()
@@ -98,7 +127,8 @@ Examples:
 def install_dependencies():
     """Install all required dependencies for GeoPublicHealth on macOS."""
 
-    # Parse arguments (only when run from command line, not when pasted in console)
+    # Parse arguments (only when run from command line, not when pasted in
+    # console)
     try:
         args = parse_args()
         python_exe = args.python_path
@@ -115,7 +145,8 @@ def install_dependencies():
     # Determine log file path
     if not log_file:
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        log_path = Path(f"./geopublichealth_install_{timestamp}.log").absolute()
+        log_filename = f"geopublichealth_install_{timestamp}.log"
+        log_path = Path(f"./{log_filename}").absolute()
     else:
         log_path = Path(log_file).absolute()
 
@@ -136,18 +167,18 @@ def install_dependencies():
         print("\n" + "!" * 70)
         print("⚠️  WARNING: This may NOT be QGIS's Python!")
         print("!" * 70)
-        print("\nYou appear to be running with system/Homebrew/Anaconda Python.")
+        print("\nYou appear to be running system/Homebrew/Anaconda Python.")
         print("Dependencies installed here will NOT be available in QGIS.")
         print("\nQGIS Python is usually located at:")
         print("  /Applications/QGIS.app/Contents/MacOS/bin/python3")
-        print("\nRECOMMENDED: Run this script from QGIS Python Console instead.")
+        print("\nRECOMMENDED: Run this from QGIS Python Console.")
         print("See installation instructions in README.md or INSTALL_MAC.md")
         print("\n" + "!" * 70)
 
         if not non_interactive:
             response = input("\nContinue anyway? (yes/no): ").strip().lower()
-            if response not in ['yes', 'y']:
-                print("\nInstallation cancelled. Please run from QGIS Python Console.")
+            if response not in ["yes", "y"]:
+                print("\nInstallation cancelled. Use QGIS Python Console.")
                 return False
         print("\nProceeding with current Python (you have been warned)...")
 
@@ -182,7 +213,12 @@ def install_dependencies():
     failed = []
 
     for name, packages, description in dependencies:
-        print(f"\n[{len(installed) + len(failed) + 1}/{len(dependencies)}] Installing {name}...")
+        print(
+            (
+                f"\n[{len(installed) + len(failed) + 1}/{len(dependencies)}] "
+                f"Installing {name}..."
+            )
+        )
         print("-" * 70)
 
         try:
@@ -193,16 +229,16 @@ def install_dependencies():
 
             # Write to log
             with open(log_path, "a", encoding="utf-8") as log:
-                log.write(f"\n{'='*70}\n")
+                log.write(f"\n{'=' * 70}\n")
                 log.write(f">>> {' '.join(cmd)}\n")
-                log.write(f"{'='*70}\n")
+                log.write(f"{'=' * 70}\n")
 
             # Run pip install
             result = subprocess.run(
                 cmd,
                 capture_output=True,
                 text=True,
-                timeout=timeout
+                timeout=timeout,
             )
 
             # Write full output to log
@@ -232,7 +268,7 @@ def install_dependencies():
                 failed.append(name)
 
         except subprocess.TimeoutExpired:
-            error_msg = f"✗ {name} installation timed out (exceeded {timeout} seconds)"
+            error_msg = f"✗ {name} installation timed out (> {timeout}s)"
             print(error_msg)
             with open(log_path, "a", encoding="utf-8") as log:
                 log.write(f"\n{error_msg}\n")
@@ -269,26 +305,40 @@ def install_dependencies():
     critical = {
         "libpysal": "Spatial analysis",
         "esda": "Exploratory spatial data analysis",
-        "numba": "Performance optimization"
+        "numba": "Performance optimization",
     }
+
+    def check_module(module_name):
+        cmd = [
+            python_exe,
+            "-c",
+            (
+                "import importlib; "
+                f"module = importlib.import_module('{module_name}'); "
+                "print(getattr(module, '__version__', 'unknown'))"
+            ),
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode == 0:
+            return True, result.stdout.strip()
+        return False, result.stderr.strip()
 
     all_critical_ok = True
     for module, description in critical.items():
-        try:
-            __import__(module)
-            print(f"✓ {module} is available - {description}")
-        except ImportError:
+        ok, version = check_module(module)
+        if ok:
+            print(f"✓ {module} {version} is available - {description}")
+        else:
             print(f"✗ {module} is NOT available - {description}")
             all_critical_ok = False
 
     # Check optional dependencies
     print("\nOptional dependencies:")
-    try:
-        import matplotlib
-
-        print(f"✓ matplotlib is available (version {matplotlib.__version__})")
-    except ImportError:
-        print("○ matplotlib is not available (plotting features will be disabled)")
+    ok, version = check_module("matplotlib")
+    if ok:
+        print(f"✓ matplotlib is available (version {version})")
+    else:
+        print("○ matplotlib not available (plotting disabled)")
 
     # Final message
     print("\n" + "=" * 70)
@@ -303,7 +353,8 @@ def install_dependencies():
     elif all_critical_ok:
         print("PARTIAL SUCCESS - Core dependencies are installed.")
         print(
-            "\nSome optional packages failed, but the plugin should work for basic features."
+            "\nSome optional packages failed, but the plugin should work for "
+            "basic features."
         )
         print("\nNext steps:")
         print("1. Restart QGIS for changes to take effect")
@@ -312,15 +363,19 @@ def install_dependencies():
         exit_code = 0
     else:
         print("INSTALLATION INCOMPLETE")
-        print(
-            "\nSome required dependencies failed to install."
-        )
+        print("\nSome required dependencies failed to install.")
         print(f"\nFull installation log: {log_path}")
-        print("\nPlease try running install_dependencies_console.py from QGIS Python Console")
-        print("Or see INSTALL_MAC.md and MAC_INSTALL_TECHNICAL.md for troubleshooting.")
+        print(
+            "\nPlease try running install_dependencies_console.py from QGIS "
+            "Python Console"
+        )
+        print("See INSTALL_MAC.md and MAC_INSTALL_TECHNICAL.md for help.")
         print("\nIf reporting an issue, please attach:")
         print(f"  - Log file: {log_path}")
-        print(f"  - QGIS version: (run in QGIS console: from qgis.core import QgsApplication; print(QgsApplication.version()))")
+        print(
+            "  - QGIS version: (run in QGIS console: from qgis.core import "
+            "QgsApplication; print(QgsApplication.version()))"
+        )
         print(f"  - macOS version: (run in terminal: sw_vers)")
         exit_code = 1
 

--- a/install_mac_dependencies.sh
+++ b/install_mac_dependencies.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+# GeoPublicHealth macOS Dependency Installer
+#
+# This script installs all required dependencies for the GeoPublicHealth QGIS plugin on macOS.
+#
+# USAGE:
+#   1. Open Terminal
+#   2. Navigate to this directory: cd /path/to/GeoPublicHealth
+#   3. Make script executable: chmod +x install_mac_dependencies.sh
+#   4. Run: ./install_mac_dependencies.sh
+#
+# Or run directly:
+#   bash install_mac_dependencies.sh
+
+echo "======================================================================"
+echo "GeoPublicHealth macOS Dependency Installer"
+echo "======================================================================"
+echo ""
+
+# QGIS Python path
+QGIS_PYTHON="/Applications/QGIS.app/Contents/MacOS/bin/python3"
+
+# Check if QGIS is installed
+if [ ! -f "$QGIS_PYTHON" ]; then
+    echo "ERROR: QGIS Python not found at $QGIS_PYTHON"
+    echo ""
+    echo "Please install QGIS first:"
+    echo "  https://download.qgis.org/downloads/macos/qgis-macos-pr.dmg"
+    echo ""
+    exit 1
+fi
+
+echo "Using QGIS Python: $QGIS_PYTHON"
+echo ""
+$QGIS_PYTHON --version
+echo ""
+
+echo "======================================================================"
+echo "Installing dependencies..."
+echo "======================================================================"
+echo ""
+
+# Function to install a package
+install_package() {
+    local package_name=$1
+    shift
+    local pip_args=("$@")
+
+    echo "----------------------------------------------------------------------"
+    echo "Installing $package_name..."
+    echo "----------------------------------------------------------------------"
+
+    if "$QGIS_PYTHON" -m pip install "${pip_args[@]}"; then
+        echo "✓ $package_name installed successfully"
+        return 0
+    else
+        echo "✗ $package_name installation failed"
+        return 1
+    fi
+}
+
+# Track installation status
+FAILED=""
+
+# Install pip upgrade
+install_package "pip (upgrade)" pip --upgrade || FAILED="$FAILED pip"
+
+# Install numpy
+install_package "numpy" numpy || FAILED="$FAILED numpy"
+
+# Install scipy
+install_package "scipy" scipy || FAILED="$FAILED scipy"
+
+# Install pandas
+install_package "pandas" pandas || FAILED="$FAILED pandas"
+
+# Install libpysal and esda (with special flag)
+install_package "libpysal & esda" libpysal esda --no-build-isolation || FAILED="$FAILED libpysal/esda"
+
+# Install numba
+install_package "numba" numba || FAILED="$FAILED numba"
+
+# Install matplotlib (optional)
+install_package "matplotlib (optional)" matplotlib || echo "Note: matplotlib is optional, plugin will work without it"
+
+echo ""
+echo "======================================================================"
+echo "INSTALLATION SUMMARY"
+echo "======================================================================"
+echo ""
+
+# Check critical dependencies
+echo "Verifying required dependencies..."
+echo ""
+
+CRITICAL_OK=true
+
+# Check libpysal
+if "$QGIS_PYTHON" -c "import libpysal" 2>/dev/null; then
+    VERSION=$("$QGIS_PYTHON" -c "import libpysal; print(libpysal.__version__)")
+    echo "✓ libpysal $VERSION is available"
+else
+    echo "✗ libpysal is NOT available (REQUIRED)"
+    CRITICAL_OK=false
+fi
+
+# Check numba
+if "$QGIS_PYTHON" -c "import numba" 2>/dev/null; then
+    VERSION=$("$QGIS_PYTHON" -c "import numba; print(numba.__version__)")
+    echo "✓ numba $VERSION is available"
+else
+    echo "✗ numba is NOT available (REQUIRED)"
+    CRITICAL_OK=false
+fi
+
+# Check esda
+if "$QGIS_PYTHON" -c "import esda" 2>/dev/null; then
+    VERSION=$("$QGIS_PYTHON" -c "import esda; print(esda.__version__)")
+    echo "✓ esda $VERSION is available"
+else
+    echo "✗ esda is NOT available (REQUIRED)"
+    CRITICAL_OK=false
+fi
+
+echo ""
+echo "Optional dependencies:"
+
+# Check matplotlib
+if "$QGIS_PYTHON" -c "import matplotlib" 2>/dev/null; then
+    VERSION=$("$QGIS_PYTHON" -c "import matplotlib; print(matplotlib.__version__)")
+    echo "✓ matplotlib $VERSION is available"
+else
+    echo "○ matplotlib is not available (plotting features will be disabled)"
+fi
+
+echo ""
+echo "======================================================================"
+
+if [ "$CRITICAL_OK" = true ]; then
+    echo "SUCCESS! All required dependencies are installed."
+    echo ""
+    echo "Next steps:"
+    echo "1. Open or restart QGIS"
+    echo "2. Go to Plugins > Manage and Install Plugins"
+    echo "3. Install the GeoPublicHealth plugin"
+    echo "4. Start using GeoPublicHealth!"
+else
+    echo "INSTALLATION INCOMPLETE"
+    echo ""
+    echo "Some required dependencies failed to install."
+    echo ""
+    echo "Try manual installation:"
+    echo "  $QGIS_PYTHON -m pip install libpysal esda numba --no-build-isolation"
+    echo ""
+    if [ -n "$FAILED" ]; then
+        echo "Failed packages:$FAILED"
+        echo ""
+    fi
+fi
+
+echo "======================================================================"

--- a/install_mac_dependencies.sh
+++ b/install_mac_dependencies.sh
@@ -4,6 +4,10 @@
 #
 # This script installs all required dependencies for the GeoPublicHealth QGIS plugin on macOS.
 #
+# IMPORTANT: This script installs to QGIS's Python, NOT your system Python.
+#            QGIS has its own isolated Python separate from Homebrew/Anaconda/system Python.
+#            This is correct - dependencies must be installed to QGIS's Python to work.
+#
 # USAGE:
 #   1. Open Terminal
 #   2. Navigate to this directory: cd /path/to/GeoPublicHealth
@@ -16,6 +20,9 @@
 echo "======================================================================"
 echo "GeoPublicHealth macOS Dependency Installer"
 echo "======================================================================"
+echo ""
+echo "This script will install dependencies to QGIS's Python environment."
+echo "This is separate from your system/Homebrew/Anaconda Python."
 echo ""
 
 # QGIS Python path

--- a/install_mac_dependencies.sh
+++ b/install_mac_dependencies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # GeoPublicHealth macOS Dependency Installer
 #
@@ -11,11 +11,25 @@
 # USAGE:
 #   1. Open Terminal
 #   2. Navigate to this directory: cd /path/to/GeoPublicHealth
-#   3. Make script executable: chmod +x install_mac_dependencies.sh
-#   4. Run: ./install_mac_dependencies.sh
+#   3. Run: bash install_mac_dependencies.sh
 #
-# Or run directly:
-#   bash install_mac_dependencies.sh
+# Override QGIS Python path:
+#   QGIS_PYTHON="/Applications/QGIS-LTR.app/Contents/MacOS/bin/python3" bash install_mac_dependencies.sh
+#
+# Specify log directory:
+#   LOG_DIR=/tmp bash install_mac_dependencies.sh
+
+# Strict error handling
+set -euo pipefail
+IFS=$'\n\t'
+
+# Configuration
+LOG_DIR="${LOG_DIR:-.}"
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+LOG_FILE="${LOG_DIR}/geopublichealth_install_${TIMESTAMP}.log"
+
+# QGIS Python path - can be overridden via environment variable
+QGIS_PYTHON="${QGIS_PYTHON:-/Applications/QGIS.app/Contents/MacOS/bin/python3}"
 
 echo "======================================================================"
 echo "GeoPublicHealth macOS Dependency Installer"
@@ -24,110 +38,142 @@ echo ""
 echo "This script will install dependencies to QGIS's Python environment."
 echo "This is separate from your system/Homebrew/Anaconda Python."
 echo ""
+echo "Log file: $LOG_FILE"
+echo ""
 
-# QGIS Python path
-QGIS_PYTHON="/Applications/QGIS.app/Contents/MacOS/bin/python3"
+# Check if QGIS is installed at specified path
+if [ ! -x "$QGIS_PYTHON" ]; then
+    echo "QGIS Python not found at: $QGIS_PYTHON" | tee -a "$LOG_FILE"
+    echo "" | tee -a "$LOG_FILE"
+    echo "Attempting to discover QGIS installation..." | tee -a "$LOG_FILE"
 
-# Check if QGIS is installed
-if [ ! -f "$QGIS_PYTHON" ]; then
-    echo "ERROR: QGIS Python not found at $QGIS_PYTHON"
-    echo ""
-    echo "Please install QGIS first:"
-    echo "  https://download.qgis.org/downloads/macos/qgis-macos-pr.dmg"
-    echo ""
-    exit 1
+    # Try to find QGIS installation automatically
+    candidate=""
+    for app in /Applications/QGIS*.app; do
+        if [ -d "$app" ]; then
+            python_path="$app/Contents/MacOS/bin/python3"
+            if [ -x "$python_path" ]; then
+                candidate="$python_path"
+                break
+            fi
+        fi
+    done
+
+    if [ -n "$candidate" ]; then
+        QGIS_PYTHON="$candidate"
+        echo "✓ Found QGIS Python at: $QGIS_PYTHON" | tee -a "$LOG_FILE"
+    else
+        echo "ERROR: Could not find QGIS Python." | tee -a "$LOG_FILE"
+        echo "" | tee -a "$LOG_FILE"
+        echo "Please install QGIS first:" | tee -a "$LOG_FILE"
+        echo "  https://download.qgis.org/downloads/macos/qgis-macos-pr.dmg" | tee -a "$LOG_FILE"
+        echo "" | tee -a "$LOG_FILE"
+        echo "Or set QGIS_PYTHON environment variable to the correct path:" | tee -a "$LOG_FILE"
+        echo "  QGIS_PYTHON=\"/path/to/QGIS.app/Contents/MacOS/bin/python3\" bash install_mac_dependencies.sh" | tee -a "$LOG_FILE"
+        echo "" | tee -a "$LOG_FILE"
+        exit 1
+    fi
 fi
 
-echo "Using QGIS Python: $QGIS_PYTHON"
-echo ""
-$QGIS_PYTHON --version
-echo ""
+echo "Using QGIS Python: $QGIS_PYTHON" | tee -a "$LOG_FILE"
+echo "" | tee -a "$LOG_FILE"
+"$QGIS_PYTHON" --version 2>&1 | tee -a "$LOG_FILE"
+echo "" | tee -a "$LOG_FILE"
 
 echo "======================================================================"
 echo "Installing dependencies..."
 echo "======================================================================"
 echo ""
 
-# Function to install a package
+# Function to install a package with logging
 install_package() {
     local package_name=$1
     shift
     local pip_args=("$@")
 
-    echo "----------------------------------------------------------------------"
-    echo "Installing $package_name..."
-    echo "----------------------------------------------------------------------"
+    echo "----------------------------------------------------------------------" | tee -a "$LOG_FILE"
+    echo "Installing $package_name..." | tee -a "$LOG_FILE"
+    echo "Running: $QGIS_PYTHON -m pip install ${pip_args[*]}" | tee -a "$LOG_FILE"
+    echo "----------------------------------------------------------------------" | tee -a "$LOG_FILE"
 
-    if "$QGIS_PYTHON" -m pip install "${pip_args[@]}"; then
-        echo "✓ $package_name installed successfully"
+    if "$QGIS_PYTHON" -m pip install "${pip_args[@]}" >>"$LOG_FILE" 2>&1; then
+        echo "✓ $package_name installed successfully" | tee -a "$LOG_FILE"
         return 0
     else
-        echo "✗ $package_name installation failed"
+        echo "✗ $package_name installation failed" | tee -a "$LOG_FILE"
+        echo "  See log for details: $LOG_FILE" | tee -a "$LOG_FILE"
         return 1
     fi
 }
 
 # Track installation status
-FAILED=""
+FAILED_PACKAGES=""
+CRITICAL_FAILED=false
 
-# Install pip upgrade
-install_package "pip (upgrade)" pip --upgrade || FAILED="$FAILED pip"
+# Install packages (continue even if one fails to see all results)
+set +e  # Don't exit on error for package installations
 
-# Install numpy
-install_package "numpy" numpy || FAILED="$FAILED numpy"
+install_package "pip (upgrade)" pip --upgrade || FAILED_PACKAGES="$FAILED_PACKAGES pip"
 
-# Install scipy
-install_package "scipy" scipy || FAILED="$FAILED scipy"
+install_package "numpy" numpy || FAILED_PACKAGES="$FAILED_PACKAGES numpy"
 
-# Install pandas
-install_package "pandas" pandas || FAILED="$FAILED pandas"
+install_package "scipy" scipy || FAILED_PACKAGES="$FAILED_PACKAGES scipy"
 
-# Install libpysal and esda (with special flag)
-install_package "libpysal & esda" libpysal esda --no-build-isolation || FAILED="$FAILED libpysal/esda"
+install_package "pandas" pandas || FAILED_PACKAGES="$FAILED_PACKAGES pandas"
 
-# Install numba
-install_package "numba" numba || FAILED="$FAILED numba"
+install_package "libpysal & esda" libpysal esda --no-build-isolation || {
+    FAILED_PACKAGES="$FAILED_PACKAGES libpysal/esda"
+    CRITICAL_FAILED=true
+}
 
-# Install matplotlib (optional)
-install_package "matplotlib (optional)" matplotlib || echo "Note: matplotlib is optional, plugin will work without it"
+install_package "numba" numba || {
+    FAILED_PACKAGES="$FAILED_PACKAGES numba"
+    CRITICAL_FAILED=true
+}
+
+install_package "matplotlib (optional)" matplotlib || echo "Note: matplotlib is optional, plugin will work without it" | tee -a "$LOG_FILE"
+
+set -e  # Re-enable exit on error
 
 echo ""
 echo "======================================================================"
 echo "INSTALLATION SUMMARY"
 echo "======================================================================"
 echo ""
-
-# Check critical dependencies
-echo "Verifying required dependencies..."
+echo "Log file: $LOG_FILE"
 echo ""
 
-CRITICAL_OK=true
+# Check critical dependencies
+echo "Verifying required dependencies..." | tee -a "$LOG_FILE"
+echo ""
+
+VERIFY_FAILED=false
 
 # Check libpysal
 if "$QGIS_PYTHON" -c "import libpysal" 2>/dev/null; then
     VERSION=$("$QGIS_PYTHON" -c "import libpysal; print(libpysal.__version__)")
-    echo "✓ libpysal $VERSION is available"
+    echo "✓ libpysal $VERSION is available" | tee -a "$LOG_FILE"
 else
-    echo "✗ libpysal is NOT available (REQUIRED)"
-    CRITICAL_OK=false
+    echo "✗ libpysal is NOT available (REQUIRED)" | tee -a "$LOG_FILE"
+    VERIFY_FAILED=true
 fi
 
 # Check numba
 if "$QGIS_PYTHON" -c "import numba" 2>/dev/null; then
     VERSION=$("$QGIS_PYTHON" -c "import numba; print(numba.__version__)")
-    echo "✓ numba $VERSION is available"
+    echo "✓ numba $VERSION is available" | tee -a "$LOG_FILE"
 else
-    echo "✗ numba is NOT available (REQUIRED)"
-    CRITICAL_OK=false
+    echo "✗ numba is NOT available (REQUIRED)" | tee -a "$LOG_FILE"
+    VERIFY_FAILED=true
 fi
 
 # Check esda
 if "$QGIS_PYTHON" -c "import esda" 2>/dev/null; then
     VERSION=$("$QGIS_PYTHON" -c "import esda; print(esda.__version__)")
-    echo "✓ esda $VERSION is available"
+    echo "✓ esda $VERSION is available" | tee -a "$LOG_FILE"
 else
-    echo "✗ esda is NOT available (REQUIRED)"
-    CRITICAL_OK=false
+    echo "✗ esda is NOT available (REQUIRED)" | tee -a "$LOG_FILE"
+    VERIFY_FAILED=true
 fi
 
 echo ""
@@ -136,34 +182,45 @@ echo "Optional dependencies:"
 # Check matplotlib
 if "$QGIS_PYTHON" -c "import matplotlib" 2>/dev/null; then
     VERSION=$("$QGIS_PYTHON" -c "import matplotlib; print(matplotlib.__version__)")
-    echo "✓ matplotlib $VERSION is available"
+    echo "✓ matplotlib $VERSION is available" | tee -a "$LOG_FILE"
 else
-    echo "○ matplotlib is not available (plotting features will be disabled)"
+    echo "○ matplotlib is not available (plotting features will be disabled)" | tee -a "$LOG_FILE"
 fi
 
 echo ""
 echo "======================================================================"
 
-if [ "$CRITICAL_OK" = true ]; then
-    echo "SUCCESS! All required dependencies are installed."
-    echo ""
-    echo "Next steps:"
-    echo "1. Open or restart QGIS"
-    echo "2. Go to Plugins > Manage and Install Plugins"
-    echo "3. Install the GeoPublicHealth plugin"
-    echo "4. Start using GeoPublicHealth!"
+if [ "$VERIFY_FAILED" = false ]; then
+    echo "SUCCESS! All required dependencies are installed." | tee -a "$LOG_FILE"
+    echo "" | tee -a "$LOG_FILE"
+    echo "Next steps:" | tee -a "$LOG_FILE"
+    echo "1. Open or restart QGIS" | tee -a "$LOG_FILE"
+    echo "2. Go to Plugins > Manage and Install Plugins" | tee -a "$LOG_FILE"
+    echo "3. Install the GeoPublicHealth plugin" | tee -a "$LOG_FILE"
+    echo "4. Start using GeoPublicHealth!" | tee -a "$LOG_FILE"
+    echo "" | tee -a "$LOG_FILE"
+    echo "Installation log: $LOG_FILE" | tee -a "$LOG_FILE"
+    echo "======================================================================"
+    exit 0
 else
-    echo "INSTALLATION INCOMPLETE"
-    echo ""
-    echo "Some required dependencies failed to install."
-    echo ""
-    echo "Try manual installation:"
-    echo "  $QGIS_PYTHON -m pip install libpysal esda numba --no-build-isolation"
-    echo ""
-    if [ -n "$FAILED" ]; then
-        echo "Failed packages:$FAILED"
-        echo ""
+    echo "INSTALLATION INCOMPLETE" | tee -a "$LOG_FILE"
+    echo "" | tee -a "$LOG_FILE"
+    echo "Some required dependencies failed to install." | tee -a "$LOG_FILE"
+    echo "" | tee -a "$LOG_FILE"
+    echo "Full installation log: $LOG_FILE" | tee -a "$LOG_FILE"
+    echo "" | tee -a "$LOG_FILE"
+    if [ -n "$FAILED_PACKAGES" ]; then
+        echo "Failed packages:$FAILED_PACKAGES" | tee -a "$LOG_FILE"
+        echo "" | tee -a "$LOG_FILE"
     fi
+    echo "Try running install_dependencies_console.py from QGIS Python Console" | tee -a "$LOG_FILE"
+    echo "Or see INSTALL_MAC.md and MAC_INSTALL_TECHNICAL.md for troubleshooting." | tee -a "$LOG_FILE"
+    echo "" | tee -a "$LOG_FILE"
+    echo "If reporting an issue, please attach:" | tee -a "$LOG_FILE"
+    echo "  - Log file: $LOG_FILE" | tee -a "$LOG_FILE"
+    echo "  - QGIS version: (run: $QGIS_PYTHON -c \"from qgis.core import QgsApplication; print(QgsApplication.version())\")" | tee -a "$LOG_FILE"
+    echo "  - macOS version: (run: sw_vers)" | tee -a "$LOG_FILE"
+    echo "" | tee -a "$LOG_FILE"
+    echo "======================================================================"
+    exit 1
 fi
-
-echo "======================================================================"

--- a/install_mac_dependencies.sh
+++ b/install_mac_dependencies.sh
@@ -111,6 +111,7 @@ FAILED_PACKAGES=""
 CRITICAL_FAILED=false
 
 # Install packages (continue even if one fails to see all results)
+# IMPORTANT: Order matters! numba must be installed before libpysal/esda
 set +e  # Don't exit on error for package installations
 
 install_package "pip (upgrade)" pip --upgrade || FAILED_PACKAGES="$FAILED_PACKAGES pip"
@@ -121,13 +122,13 @@ install_package "scipy" scipy || FAILED_PACKAGES="$FAILED_PACKAGES scipy"
 
 install_package "pandas" pandas || FAILED_PACKAGES="$FAILED_PACKAGES pandas"
 
-install_package "libpysal & esda" libpysal esda --no-build-isolation || {
-    FAILED_PACKAGES="$FAILED_PACKAGES libpysal/esda"
+install_package "numba" numba || {
+    FAILED_PACKAGES="$FAILED_PACKAGES numba"
     CRITICAL_FAILED=true
 }
 
-install_package "numba" numba || {
-    FAILED_PACKAGES="$FAILED_PACKAGES numba"
+install_package "libpysal & esda" libpysal esda --no-build-isolation || {
+    FAILED_PACKAGES="$FAILED_PACKAGES libpysal/esda"
     CRITICAL_FAILED=true
 }
 

--- a/requirements-mac.txt
+++ b/requirements-mac.txt
@@ -1,0 +1,34 @@
+# GeoPublicHealth Dependencies for macOS - Pinned Versions
+#
+# This file contains pinned dependency versions for reproducible installations.
+#
+# USAGE:
+#   /Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install -r requirements-mac.txt --no-build-isolation
+#
+# Or from QGIS Python Console:
+#   import subprocess, sys
+#   subprocess.run([sys.executable, "-m", "pip", "install", "-r", "requirements-mac.txt", "--no-build-isolation"])
+#
+# NOTE: These versions are tested and known to work together. Using unpinned
+# versions (as in the automated scripts) will install the latest packages,
+# which may introduce breaking changes.
+#
+# Last tested: 2026-01-24
+# QGIS version: 3.44.x
+# macOS version: 12+, 13, 14 (Intel and Apple Silicon)
+# Python: 3.11-3.12
+
+# Core numerical/scientific libraries
+numpy>=1.24.0,<2.0.0
+scipy>=1.10.0,<2.0.0
+pandas>=2.0.0,<3.0.0
+
+# Performance optimization (must be installed before libpysal/esda)
+numba>=0.57.0,<1.0.0
+
+# Spatial analysis libraries (require --no-build-isolation)
+libpysal>=4.9.0,<5.0.0
+esda>=2.5.0,<3.0.0
+
+# Optional: Plotting and visualization
+matplotlib>=3.7.0,<4.0.0


### PR DESCRIPTION
Add multiple simplified installation methods for macOS users:

- Created install_mac_dependencies.py: Automated Python script that
  installs all required dependencies with detailed progress reporting
  and verification. Can be run from QGIS Python Console or Terminal.

- Created install_mac_dependencies.sh: Shell script alternative for
  Terminal-based installation with comprehensive error checking.

- Created INSTALL_MAC.md: Quick start guide specifically for Mac users
  with step-by-step instructions and troubleshooting tips.

- Updated README.md: Reorganized macOS section with 4 clear options
  from easiest (automated script) to most manual (step-by-step),
  added reference to new quick start guide, and reorganized
  documentation section.

- Updated DEPENDENCIES.md: Added 4 installation options for macOS
  including automated scripts, one-liner command, and manual methods.

Benefits:
- Reduces installation from 7 manual steps to 1 automated script
- Provides flexibility with 4 different installation methods
- Clearer documentation with progressive disclosure
- Better error handling and verification
- Friendlier for users of all technical levels

Addresses user request to simplify Mac installation process.